### PR TITLE
Add CI to ensure notebooks run correctly

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -1,0 +1,10 @@
+name: jupyter-actions
+channels:
+    - conda-forge
+dependencies:
+  - jupyter=1.0
+  - nbformat
+  - nbconvert
+  - numpy=1.18
+  - requests=2.24.0
+  - pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: Test Notebooks
+
+on:
+  # Allow this workflow to be run manually
+  workflow_dispatch:
+  # Run for pull requests
+  pull_request:
+    branches:
+      - main
+  # Run every time a new commit is pushed
+  push:
+    branches:
+      - main
+  # Run every week on Sunday at midnight
+  schedule:
+    - cron: "0 0 * * 1"
+
+jobs:
+  # Set the job key
+  test-notebooks:
+    # Name the job
+    name: Test Jupyter Notebooks
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install conda environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: jupyter-actions
+          environment-file: .github/environment.yml
+          python-version: 3.7
+
+      - name: Install OpenMC
+        shell: bash -l {0}
+        run: |
+          conda activate jupyter-actions
+          conda install -c conda-forge mamba
+          mamba install -c conda-forge openmc
+
+      - name: Cache Cross Sections
+        id: xs-cache
+        uses: actions/cache@v3
+        with:
+          # use this cache as long as the download script doesn't change
+          key: xs-cache-${{ hashfiles('.test/download-xs.sh') }}
+          path: ~/endfb71_hdf5/*
+
+      - name: Download OpenMC Cross Sections
+        shell: bash -l {0}
+        if: steps.xs-cache.outputs.cache-hit != 'true'
+        run: |
+          ./.test/download-xs.sh
+
+      - name: Set Environment Variables
+        shell: bash -l {0}
+        run: |
+          echo "OPENMC_CROSS_SECTIONS=$HOME/endfb71_hdf5/cross_sections.xml" >> $GITHUB_ENV
+
+      - name: Execute all Notebooks
+        shell: bash -l {0}
+        run: |
+          conda activate jupyter-actions
+          pytest -v .test

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,17 @@
 
 # Jupyter notebooks
 *.xml
+*.h5
+*.h5m
+*.vtk
 *.png
 *.xls
 *.ace
 *.endf
+*.out
 mgxs/
 tracks/
 fission-rates/
 plots/
+*~
+*__pycache__*

--- a/.test/clear_notebooks_test.py
+++ b/.test/clear_notebooks_test.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor
+from nbconvert.preprocessors import CellExecutionError
+
+import pytest
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+
+
+def process_notebook(notebook_filename, html_directory = 'notebook-html'):
+    '''Checks if an IPython notebook runs without error from start to finish. If so, writes the notebook to HTML (with outputs) and overwrites the .ipynb file (without outputs).
+    '''
+    with open(notebook_filename) as f:
+        nb = nbformat.read(f, as_version=4)
+    
+    ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+
+    try:
+        # Check that the notebook runs
+        ep.preprocess(nb, {'metadata': {'path': ''}})
+    except CellExecutionError:
+        msg = f'Error executing the notebook {notebook_filename}.\n\n'
+        msg += f'See notebook "{notebook_filename}" for the traceback.'
+        #print(msg)
+        raise
+         
+    print(f"Successfully executed {notebook_filename}")
+    return
+    
+def test_process_notebook():
+
+    with pytest.raises(CellExecutionError):
+        process_notebook(os.path.join(TEST_DIR,'notebook-fails'))
+
+    assert(process_notebook(os.path.join(TEST_DIR,'notebook-pass')) is None)
+
+if __name__ == '__main__':
+    test_process_notebook()

--- a/.test/clear_notebooks_test.py
+++ b/.test/clear_notebooks_test.py
@@ -4,19 +4,19 @@ import subprocess
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors import CellExecutionError
-
 import pytest
+
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-
-
 def process_notebook(notebook_filename, html_directory = 'notebook-html'):
-    '''Checks if an IPython notebook runs without error from start to finish. If so, writes the notebook to HTML (with outputs) and overwrites the .ipynb file (without outputs).
+    '''Checks if an IPython notebook runs without error from start to finish. If so,
+    writes the notebook to HTML (with outputs) and overwrites the .ipynb file
+    (without outputs).
     '''
     with open(notebook_filename) as f:
         nb = nbformat.read(f, as_version=4)
-    
+
     ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
 
     try:
@@ -25,12 +25,13 @@ def process_notebook(notebook_filename, html_directory = 'notebook-html'):
     except CellExecutionError:
         msg = f'Error executing the notebook {notebook_filename}.\n\n'
         msg += f'See notebook "{notebook_filename}" for the traceback.'
-        #print(msg)
+        print(msg)
         raise
-         
+
     print(f"Successfully executed {notebook_filename}")
     return
-    
+
+
 def test_process_notebook():
 
     with pytest.raises(CellExecutionError):
@@ -38,5 +39,6 @@ def test_process_notebook():
 
     assert(process_notebook(os.path.join(TEST_DIR,'notebook-pass')) is None)
 
+
 if __name__ == '__main__':
-    test_process_notebook()
+    pytest.main()

--- a/.test/download-xs.sh
+++ b/.test/download-xs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex
+
+cd $HOME
+wget https://anl.box.com/shared/static/9igk353zpy8fn9ttvtrqgzvw1vtejoz6.xz -O endf7b_xs.tar.xz
+tar xf endf7b_xs.tar.xz

--- a/.test/notebook-fails
+++ b/.test/notebook-fails
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "save_html"
+    ]
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-09-25T12:29:32.718006Z",
+     "iopub.status.busy": "2020-09-25T12:29:32.716176Z",
+     "iopub.status.idle": "2020-09-25T12:29:32.838050Z",
+     "shell.execute_reply": "2020-09-25T12:29:32.836977Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "1 + \"a\""
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/.test/notebook-pass
+++ b/.test/notebook-pass
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "save_html"
+    ]
+   },
+   "source": [
+    "# Test notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook passes the test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-09-25T17:55:34.624627Z",
+     "iopub.status.busy": "2020-09-25T17:55:34.622763Z",
+     "iopub.status.idle": "2020-09-25T17:55:34.631046Z",
+     "shell.execute_reply": "2020-09-25T17:55:34.632276Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "1 + 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-09-25T17:55:34.640643Z",
+     "iopub.status.busy": "2020-09-25T17:55:34.638873Z",
+     "iopub.status.idle": "2020-09-25T17:55:34.644490Z",
+     "shell.execute_reply": "2020-09-25T17:55:34.645412Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/.test/test_notebooks.py
+++ b/.test/test_notebooks.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor
+from nbconvert.preprocessors import CellExecutionError
+import pytest
+
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+PARENT_DIR = os.path.join(TEST_DIR, '..')
+
+
+def process_notebook(notebook_filename, html_directory = 'notebook-html'):
+    '''Checks if an IPython notebook runs without error from start to finish. If so,
+    writes the notebook to HTML (with outputs) and overwrites the .ipynb file
+    (without outputs).
+    '''
+
+    with open(notebook_filename) as f:
+        nb = nbformat.read(f, as_version=4)
+
+    ep = ExecutePreprocessor(timeout=600,
+                             kernel_name='python3',
+                             allow_errors=True)
+
+    try:
+        # Check that the notebook runs
+        ep.preprocess(nb, {'metadata': {'path': ''}})
+    except CellExecutionError:
+        raise
+
+    print(f"Successfully executed {notebook_filename}")
+    return
+
+
+def find_notebooks():
+    # Get all files included in the git repository
+    git_files = (subprocess
+                 .check_output("git ls-tree --full-tree --name-only -r HEAD", shell=True)
+                 .decode('utf-8')
+                 .splitlines())
+
+    # Get just the notebooks from the git files
+    return [fn for fn in git_files if fn.endswith(".ipynb")]
+
+
+@pytest.mark.parametrize('notebook', find_notebooks())
+def test_all_notebooks(notebook, remove_fail_test=True):
+    '''Runs `process_notebook` on all notebooks in the git repository.
+    '''
+
+    print("Testing", notebook)
+    process_notebook(os.path.join(PARENT_DIR, notebook))
+
+    # clean out files when test is complete
+    subprocess.check_output("git clean -dxf", shell=True)
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/unstructured-mesh-part-i.ipynb
+++ b/unstructured-mesh-part-i.ipynb
@@ -517,7 +517,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.settings.particles = 100_000\n",
+    "model.settings.particles = 10_000\n",
     "model.settings.inactive = 20\n",
     "model.settings.batches = 100\n",
     "sp_file = model.run(output=False)"


### PR DESCRIPTION
This adds CI to the repo so we can ensure they all run correctly and are up-to-date with changes in the API.

It currently uses the latest release of OpenMC installed via `mamba`. As a follow-on to this PR, I'd like to run these tests against the OpenMC `develop` branch so we can detect changes as they come to make more incremental changes for updates to the API. Some pytest parametrization provides a test for each notebook, resulting in the following output:

```
.test/test_notebooks.py::test_all_notebooks[cad-based-geometry.ipynb] PASSED [  7%]
.test/test_notebooks.py::test_all_notebooks[candu.ipynb] PASSED          [ 11%]
.test/test_notebooks.py::test_all_notebooks[capi.ipynb] PASSED           [ 15%]
.test/test_notebooks.py::test_all_notebooks[depletion.ipynb] PASSED      [ 19%]
.test/test_notebooks.py::test_all_notebooks[expansion-filters.ipynb] PASSED [ 23%]
.test/test_notebooks.py::test_all_notebooks[flux-spectrum.ipynb] PASSED  [ 26%]
.test/test_notebooks.py::test_all_notebooks[hexagonal-lattice.ipynb] PASSED [ 30%]
.test/test_notebooks.py::test_all_notebooks[mdgxs-part-i.ipynb] PASSED   [ 34%]
.test/test_notebooks.py::test_all_notebooks[mdgxs-part-ii.ipynb] PASSED  [ 38%]
.test/test_notebooks.py::test_all_notebooks[mg-mode-part-i.ipynb] PASSED [ 42%]
```

These tests can be run locally as well to make local updates to the notebooks less tedious.

There's a cron setting that will run the workflow weekly. It will also be run for pull requests and on any push to the `main` branch.

I'll just note that these tests check for successful execution, not for correctness or consistency in results/output. Those should still be checked visually.