### PR TITLE
Removing `allow_errors` and adding dependencies to CI

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -8,3 +8,7 @@ dependencies:
   - numpy=1.18
   - requests=2.24.0
   - pytest
+  - vtk
+  - pyevtk
+  - xlwt
+  - swig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+
       - name: Install conda environment
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -59,6 +60,28 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "OPENMC_CROSS_SECTIONS=$HOME/endfb-vii.1-hdf5/cross_sections.xml" >> $GITHUB_ENV
+
+      - name: Install Additional Python Dependencies
+        shell: bash -l {0}
+        run: |
+          conda init bash
+          source ~/.bashrc
+          conda activate jupyter-actions
+          pip install vtk pyevtk xlwt swig
+
+      - name: Install OpenMOC
+        shell: bash -l {0}
+        run: |
+          conda init bash
+          source ~/.bashrc
+          conda activate jupyter-actions
+          cd ~
+          git clone https://github.com/mit-crpg/openmoc &&
+          cd openmoc
+          # OpenMOC has some custom commands that rely on setuptools/distutils
+          python setup.py install
+          # install twice to make sure openmoc.py is copied into the installation location
+          python setup.py install
 
       - name: Execute all Notebooks
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,6 @@ jobs:
         run: |
           echo "OPENMC_CROSS_SECTIONS=$HOME/endfb-vii.1-hdf5/cross_sections.xml" >> $GITHUB_ENV
 
-      - name: Install Additional Python Dependencies
-        shell: bash -l {0}
-        run: |
-          conda init bash
-          source ~/.bashrc
-          conda activate jupyter-actions
-          pip install vtk pyevtk xlwt swig
-
       - name: Install OpenMOC
         shell: bash -l {0}
         run: |

--- a/.test/test_notebooks.py
+++ b/.test/test_notebooks.py
@@ -21,8 +21,7 @@ def process_notebook(notebook_filename, html_directory='notebook-html'):
         nb = nbformat.read(f, as_version=4)
 
     ep = ExecutePreprocessor(timeout=600,
-                             kernel_name='python3',
-                             allow_errors=True)
+                             kernel_name='python3')
 
     try:
         # Check that the notebook runs


### PR DESCRIPTION
We found in #6 that the `allow_error=True` was causing a subset of errors to be caught by CI. If that line is removed from the execution preprocessor, errors for missing dependences appear. 

This removes that line and adds the missing dependencies to the CI environment. 