### PR TITLE
Add missing <nuclide> entries to chain_simple.xml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Install conda environment
         uses: conda-incubator/setup-miniconda@v2
         with:
+          mamba-version: "*"
           activate-environment: jupyter-actions
           environment-file: .github/environment.yml
           python-version: 3.7

--- a/chain_simple.xml
+++ b/chain_simple.xml
@@ -78,4 +78,29 @@
       </fission_yields>
     </neutron_fission_yields>
   </nuclide>
+  <nuclide>  <!-- Target nuclides to allow depletion to run smoothly -->
+    <nuclide name="Cs136" decay_modes="0" reactions="0" />
+  <nuclide>
+    <nuclide name="Cs138" decay_modes="0" reactions="0" />
+  </nuclide>
+  <nuclide>
+    <nuclide name="Cs138_m1" decay_modes="0" reactions="0" />
+  </nuclide>
+  <nuclide>
+    <nuclide name="Ba135" decay_modes="0" reactions="0" />
+  </nuclide>
+  <nuclide>
+    <nuclide name="Ba136" decay_modes="0" reactions="0" />
+  </nuclide>
+  <nuclide>
+    <nuclide name="Ba138" decay_modes="0" reactions="0" />
+  </nuclide>
+  <nuclide>
+    <nuclide name="Xe134" decay_modes="0" reactions="0" />
+  </nuclide>
+  </nuclide>
+    <nuclide name="Xe137" decay_modes="0" reactions="0" />
+  <nuclide>
+    <nuclide name="I134" decay_modes="0" reactions="0" />
+  </nuclide>
 </depletion_chain>


### PR DESCRIPTION
I went ahead and added nuclide entries for the isotopes mentioned in #15. Let me know if the XML style is sufficient (I'm not very versed in XML so I just added them at the end).

One thing I noticed while looking at the new isotopes was these two lines
```XML
    <reaction type="(n,gamma)" Q="4281390.0" target="Cs138" branching_ratio="0.9021"/>
    <reaction type="(n,gamma)" Q="4281390.0" target="Cs138_m1" branching_ratio="0.0979"/>
```
Should these two reactions have the same Q value? My physics intuition says no since the meta-stable state has some energy given to the excitation. I'm not an expert on this reaction though, so maybe that is handled elsewhere.

Once we agree on the changes, Closes #15.