### PR TITLE
Make notebooks compatible with OpenMC version 0.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           activate-environment: jupyter-actions
           environment-file: .github/environment.yml
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install OpenMC
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           conda install -n base conda-libmamba-solver
           conda config --set solver libmamba
           conda activate jupyter-actions
-          conda install -c conda-forge openmc==0.14.0
+          conda install -c conda-forge openmc==0.15.0
 
       - name: Cache Cross Sections
         id: xs-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           source ~/.bashrc
           conda activate jupyter-actions
           cd ~
-          git clone https://github.com/mit-crpg/openmoc &&
+          git clone https://github.com/pshriwise/openmoc -b numpy-2.0 &&
           cd openmoc
           # OpenMOC has some custom commands that rely on setuptools/distutils
           python setup.py install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           source ~/.bashrc
           conda activate jupyter-actions
           cd ~
-          git clone https://github.com/pshriwise/openmoc -b numpy-2.0 &&
+          git clone https://github.com/mit-crpg/openmoc &&
           cd openmoc
           # OpenMOC has some custom commands that rely on setuptools/distutils
           python setup.py install

--- a/.test/test_notebooks.py
+++ b/.test/test_notebooks.py
@@ -43,8 +43,6 @@ def find_notebooks():
     # Get just the notebooks from the git files
     notebooks = [fn for fn in git_files if fn.endswith(".ipynb")]
     # remove the MGXS notebooks that use on OepnMOC for now
-    notebooks.remove('mgxs-part-ii.ipynb')
-    notebooks.remove('mgxs-part-iii.ipynb')
     return notebooks
 
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@ OpenMC Notebooks
 ----------------
 
 This repository contains a set of example Jupyter notebooks demonstrating
-various capabilities in OpenMC from model building to advanced features like
-depletion/activation and CAD geometry.
+various capabilities in OpenMC from basic model building to advanced features
+such as depletion/activation, CAD geometry universes, etc.
 
 Notebook versioning
 -------------------
 
-Notebooks contained in the `main` branch of this repository should work with the
-latest version of OpenMC. Note, `main` **is not the default branch of this
-repository** and must be checked out after cloning the repo.
+Notebooks contained in the `main` branch of this repository can be expected to
+work with the latest release of OpenMC. Note, `main` **is not the default branch
+of this repository** and must be checked out after cloning the repo.
 
-Previous versions of the notebooks will be tagged with the corresponding OpenMC
-version with which they work. These tags can be used to checkout notebooks
-ensured to be compatible with the corresponding release of OpenMC.
+Previous versions notebooks will be tagged with the corresponding OpenMC version
+with which they are expected to work. These tags can be used to checkout
+notebooks ensured to be compatible with the corresponding release of OpenMC.
 
 Continuous development of these notebooks occurs in the `develop` branch, the
 default branch of this repository. We ask that any updates or contributions to

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+OpenMC Notebooks
+----------------
+
+This repository contains a set of example Jupyter notebooks demonstrating
+various capabilities in OpenMC from model building to advanced features like
+depletion/activation and CAD geometry.
+
+Notebook versioning
+-------------------
+
+Notebooks contained in the `main` branch of this repository should work with the
+latest version of OpenMC. Note, `main` **is not the default branch of this
+repository** and must be checked out after cloning the repo.
+
+Previous versions of the notebooks will be tagged with the corresponding OpenMC
+version with which they work. These tags can be used to checkout notebooks
+ensured to be compatible with the corresponding release of OpenMC.
+
+Continuous development of these notebooks occurs in the `develop` branch, the
+default branch of this repository. We ask that any updates or contributions to
+the repository occur based on this branch.

--- a/candu.ipynb
+++ b/candu.ipynb
@@ -360,6 +360,7 @@
     "settings.batches = 20\n",
     "settings.inactive = 10\n",
     "settings.source = openmc.IndependentSource(space=openmc.stats.Point())\n",
+    "settings.output = {'tallies' : False}\n",
     "settings.export_to_xml()"
    ]
   },


### PR DESCRIPTION
This PR contains a few small changes to ensure that all of the notebooks will run OpenMC version 0.15.0.

Following this PR, I plan to create a new, stable branch for this repo called `main` that will always work with the latest release of OpenMC. The intent is to provide users relying on stable versions of OpenMC (e.g. via conda installations or Docker images) with a version of reliable example notebooks. These plans are reflected in the README I've added here.

