### PR TITLE
Restrict swig version to keep OpenMOC build from breaking.

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - pytest
   - vtk
   - pyevtk
-  - swig
+  - swig==4.2.1


### PR DESCRIPTION
An update to a signature in `swig` 4.3 broke the OpenMOC build we use in CI here. This PR simply pins the swig installation in the environment file to use a previous version that's compatible with OpenMOC.