### PR TITLE
Adding a notebook on synchronizing DAGMC universes

### DIFF
--- a/cad-model-sync.ipynb
+++ b/cad-model-sync.ipynb
@@ -297,7 +297,7 @@
       "         License | https://docs.openmc.org/en/latest/license.html\n",
       "         Version | 0.15.1\n",
       "     Commit Hash | 906548db20d4ce3c322e7317992c73b51daeb11d\n",
-      "       Date/Time | 2025-03-17 23:10:09\n",
+      "       Date/Time | 2025-03-17 23:20:12\n",
       "  OpenMP Threads | 16\n",
       "\n",
       " Reading settings XML file...\n",
@@ -516,11 +516,199 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's revert that change and explore another capability this provides -- the ability to differentiate materials in DAGMC universes.\n"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "fuel_cell.fill = u235"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "The `Model.diferentiate_mats` method automates the process of defining unique materials where they applied in multiple cells in a model for the purpose of separating burn up or activation of material in different regions.\n",
+    "\n",
+    "We'll demonstrate this with the pincell model, which has two cells in its interior that are filled with a fuel material. To start, we'll see we have two materials in the universe: U235 fuel and water."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{40: Material\n",
+       " \tID             =\t40\n",
+       " \tName           =\tfuel\n",
+       " \tTemperature    =\tNone\n",
+       " \tDensity        =\t11 [g/cc]\n",
+       " \tVolume         =\tNone [cm^3]\n",
+       " \tDepletable     =\tTrue\n",
+       " \tS(a,b) Tables  \n",
+       " \tNuclides       \n",
+       " \tU235           =\t1.0          [ao],\n",
+       " 41: Material\n",
+       " \tID             =\t41\n",
+       " \tName           =\twater\n",
+       " \tTemperature    =\tNone\n",
+       " \tDensity        =\t1.0 [g/cc]\n",
+       " \tVolume         =\tNone [cm^3]\n",
+       " \tDepletable     =\tFalse\n",
+       " \tS(a,b) Tables  \n",
+       " \tS(a,b)         =\t('c_H_in_H2O', 1.0)\n",
+       " \tNuclides       \n",
+       " \tH1             =\t2.0          [ao]\n",
+       " \tO16            =\t1.0          [ao]}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dag_univ.get_all_materials()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: xlabel='x [cm]', ylabel='y [cm]'>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAARYAAAEHCAYAAABrx2lxAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAGxhJREFUeJzt3X9QFOf9B/A3GO5AgQMU7iSCYrAafyRYqwY01h+MqLGpjeOYsVGMFoVAWsRpI6NVU6t0jI1Uo8S0gjZj1GrGJLWJEUmiaYM60GBEKw2ORgQPsZU7NPVAeL5/5MslBwK3d89yd9z7NbMz3N6zu5/bYd/33LO3ez5CCAEiIol8XV0AEfU8DBYiko7BQkTSMViISDoGCxFJx2AhIukYLEQkHYOFiKR7yNUFuJuWlhbU1NQgKCgIPj4+ri6HyK0IIdDQ0IDIyEj4+nbcL2GwtFFTU4OoqChXl0Hk1qqqqjBgwIAOn2ewtBEUFAQAmPbzSjykDXJxNUTu5b6lAUXbYq3HSUcYLG20fvx5SBuEy193nMhE3mZYqNn6d1fDBBy8JSLpGCxEJB2DhYikY7AQkXQMFiKSjsFCRNIxWIhIOgYLEUnHYCEi6RgsRCQdg4WIpGOwEJF0DBYiks5jgiUnJwdjx45FUFAQIiIiMGfOHFRUVNi0uXfvHtLT09G3b18EBgZi7ty5qK2tdVHFRN7LY4Ll5MmTSE9Px+nTp1FYWIimpiZMnz4dd+/etbZZsWIF/vrXv+LQoUM4efIkampq8Mwzz7iwaiLv5DH3Yzl27JjN4z179iAiIgKlpaWYNGkSTCYTdu/ejbfeegtTp04FABQUFODRRx/F6dOn8cQTT7iibCKv5DE9lrZMJhMAICwsDABQWlqKpqYmJCYmWtsMGzYM0dHRKC4u7nA9FosFZrPZZiIi53hksLS0tCAzMxMTJkzAyJEjAQBGoxEajQYhISE2bfV6PYxGY4frysnJgU6ns0683y2R8zwyWNLT01FeXo4DBw44va7s7GyYTCbrVFVVJaFCIu/mMWMsrTIyMnD06FGcOnXK5i7hBoMBjY2NqK+vt+m11NbWwmAwdLg+rVYLrVarZslEXsdjeixCCGRkZODIkSP46KOPEBMTY/P8mDFj4Ofnh6KiIuu8iooKXLt2DfHx8d1dLpFX85geS3p6Ot566y28++67CAoKso6b6HQ6BAQEQKfTYenSpcjKykJYWBiCg4Px4osvIj4+nmeEiLqZxwRLXl4eAGDy5Mk28wsKCrB48WIAwNatW+Hr64u5c+fCYrEgKSkJO3fu7OZKichjgkUI0WUbf39/7NixAzt27OiGioioIx4zxkJEnoPBQkTSMViISDoGCxFJx2AhIukYLEQkHYOFiKRjsBCRdAwWIpKOwUJE0jFYiEg6BgsRScdgISLpGCxEJB2DhYikY7AQkXQMFiKSjsFCRNIxWIhIOgYLEUnHYCEi6RgsRCQdg4WIpGOwEJF0DBYiko7BQkTSMViISDoGCxFJx2AhIukecnUBSpw6dQqvvPIKSktLcePGDRw5cgRz5syxPi+EwLp16/DHP/4R9fX1mDBhAvLy8jBkyBDXFU12mT6rzKHljr8fJ7UOksOjguXu3bt4/PHHsWTJEjzzzDPtnt+8eTO2bduGvXv3IiYmBr/+9a+RlJSEixcvwt/f3wUVU0ccDZKu1sOgcQ8eFSwzZ87EzJkzH/icEAK5ublYs2YNfvzjHwMA/vznP0Ov1+Odd97Bs88+252lUhuygkTpdhg0ruFRwdKZK1euwGg0IjEx0TpPp9Nh/PjxKC4u7jBYLBYLLBaL9bHZbFa9Vm/SXYHS1fYZMN2rxwSL0WgEAOj1epv5er3e+tyD5OTk4OWXX1a1Nm/k6kBpiwHTvbz+rFB2djZMJpN1qqqqcnVJHm36rDK3C5Xvcvf6eooe02MxGAwAgNraWvTv3986v7a2FnFxcR0up9VqodVq1S6vx/O0g5U9GHX1mB5LTEwMDAYDioqKrPPMZjPOnDmD+Ph4F1bWs3l6D8DT63dXHtVjuXPnDiorK62Pr1y5grKyMoSFhSE6OhqZmZn47W9/iyFDhlhPN0dGRtp814XkkX1APj16hKL2731+Qdq2p88qY+9FIo8KlpKSEkyZMsX6OCsrCwCQnJyMPXv24Fe/+hXu3r2LZcuWob6+HhMnTsSxY8f4HRYVyAgVpUHS1fLOBg3DRR4fIYRwdRHuxGw2Q6fTIemXtbj89QBXl+N2nA0UZ8PEXs6GDAOmvWGhZjRZzPjwFT1MJhOCg4M7bNtjxlhIfc6EytOjR3RbqMjYHsddnMNgIbs4eqB1d6DI3D7DxXEMFuqSIweYqwOlLUfrYbg4hsFCnVJ6YLlboLTlSH0MF+UYLNQhR0LFUzBc1OVRp5vJfckKlYOvFXXdCMD8jGlOb+vp0SOkfheGvsVgoQdS8g7tTKjYGyRdLedo0CgJF37PxX4MFmpH7VBxNEzsXafSkGG4yMcxFrKhZqgcfK1IlVCRsR0lr4XjLV1jsJBDHAmV7qZmuFDnGCxkZe87sZIDsLt6KbK2b+9rY6+lcwwWUkRpqLgLNcKFOmbX4G3rVcRKrFmzBmFhYYqXI9ew5x3YU0Ol1cHXiuwe2LVnQJcDuR2zK1hyc3MRHx8PjUZj10r//ve/IyMjg8HipdwxVFopCRdynN2nm48cOYKIiAi72gYFBTlcEHU/mb0Vdw6VVvaGC3stjrNrjKWgoAA6nc7ule7atavd3fKp5/OEUGnlSbV6IruCJTk5WdENpxcsWIA+ffo4XBR1H1m9FU88UO2p2Z7XzjNE7Tn1zds7d+6gpaXFZl5nd5UiIu+g+HTzlStX8NRTT6FPnz7Q6XQIDQ1FaGgoQkJCEBoaqkaNpBJv7q20Yq9FHYp7LM899xyEEMjPz4der4ePj48adZGH8ORQacUzRfIpDpZz586htLQUQ4cOVaMeciP8oti3eIsFZRR/FBo7dix/hpQA9IzeSque9FrcgeIey5/+9CekpqaiuroaI0eOhJ+fn83zjz32mLTiSD0cE5CP32n5luJgqaurw+XLl/H8889b5/n4+EAIAR8fHzQ3N0stkFyDH4Pa48ch+ykOliVLlmD06NHYv38/B2+9WE/86MBBXHkUB8tXX32F9957D7GxsWrUQ0Q9gOLB26lTp+LcuXNq1ELdhOMr6uG+/YbiHsuPfvQjrFixAufPn8eoUaPaDd4+/fTT0ooj1+D4Ssc4zmIfxcGSmpoKAPjNb37T7jkO3nqHnji+0orjLHIo/ijU0tLS4eQuobJjxw4MGjQI/v7+GD9+PM6ePevqkoi8So+7NeXBgweRlZWFdevW4Z///Ccef/xxJCUl4ebNm64ujchrKA6Wn//859i2bVu7+a+99hoyMzNl1OSUV199FSkpKXj++ecxfPhwvP766+jduzfy8/NdXRqR11AcLG+//TYmTJjQbn5CQgIOHz4spShHNTY2orS0FImJidZ5vr6+SExMRHFx8QOXsVgsMJvNNhMROUdxsPznP/954N3kgoODcevWLSlFOerWrVtobm5ud/c6vV4Po9H4wGVycnKg0+msU1RUVHeUStSjKQ6W2NhYHDt2rN38Dz74AIMHD5ZSVHfKzs6GyWSyTrzAksh5ik83Z2VlISMjA3V1dZg6dSoAoKioCL///e+Rm5sruz5F+vXrh169eqG2ttZmfm1tLQwGwwOX0Wq1im67SURdc+haIYvFgo0bN2LDhg0AgEGDBiEvLw+LFi2SXqASGo0GY8aMQVFREebMmQPgm9PjRUVFyMjIcGltRN7EoXvepqWlIS0tDXV1dQgICEBgYKDsuhyWlZWF5ORk/OAHP8C4ceOQm5uLu3fv2lyNTUTqcupm2uHh4bLqkGb+/Pmoq6vD2rVrYTQaERcXh2PHjvHnSCSanzGtx377lt+6lcOuwdvvf//7uH37tt0rnThxIqqrqx0uylkZGRn46quvYLFYcObMGYwfP95ltXgiXgvTMe4b+9jVYykrK8O5c+fs/snUsrIyWCwWpwoj9Rx/P45X4aqEd5D7ht0fhaZNmwYhhF1tefMnIu9mV7BcuXJF8YoHDBigeBnyHD1xnIXjK/LYFSwDBw5Uuw5yM+99foH3ZWmD4yv263FXN5N9OBYgH/fptxgs5LCe9NGhJ70Wd8BgoQ6x6/8t7gtlGCzklJ7wTt8TXoO7URwsycnJOHXqlBq1UDezZ0zAnndqTz4w7andnn3A8RVbioPFZDIhMTERQ4YMwaZNm1z6DVsick+Kg+Wdd95BdXU10tLScPDgQQwaNAgzZ87E4cOH0dTUpEaNpCJv7rWwt6Ieh8ZYwsPDkZWVhXPnzuHMmTOIjY3FwoULERkZiRUrVuDLL7+UXSd5AE8KF0+q1RM5NXh748YNFBYWorCwEL169cKsWbNw/vx5DB8+HFu3bpVVI6lMVq8F8IwD1t4a2VtxnOJgaWpqwttvv43Zs2dj4MCBOHToEDIzM1FTU4O9e/fixIkT+Mtf/vLAHzQj7+DO4eLOtfUkioOlf//+SElJwcCBA3H27FmUlJQgNTUVwcHB1jZTpkxBSEiIzDpJZTJ7LYB7HsBKamJvxTmKg2Xr1q2oqanBjh07EBcX98A2ISEhDl24SO7PU8NFdqhQ53yEvfdC8BJmsxk6nQ5Jv6zF5a+97wpte+/TovQCRVddCa003OwNFW/srQwLNaPJYsaHr+hhMplsPqW0xW/ekkOUvqu7oveiVqhQ1xgsZEPJO7Ej4dIdAePIdpS8Fm/srSjl1M20qWdScutKR+7b8t2DXtZHJGcCi6EiH4OFHkjtcGnVNhDsDRpZPR+GijoYLCSFrDvOdedYDMdU1MMxFuqQ0ndoTzpQldbK3ooyDBbqlCPh4s4B40h9DBXlGCzUJUcOLHcLGEfrYag4hsFCdnH0AHN1wDizfYaK4xgsZDdnDrTuDhhnt8dQcQ7PCpEirQecoz/R+t2DXfbvFskILgaKHAwWcoiM339uGwRKg0Z2D4ihIo/HBMvGjRvxt7/9DWVlZdBoNKivr2/X5tq1a0hLS8PHH3+MwMBAJCcnIycnBw895DEv06PI/nF5V47FMFTk8pgjrrGxEfPmzUN8fDx2797d7vnm5mY89dRTMBgM+Oyzz3Djxg0sWrQIfn5+2LRpkwsq9g7OfjRyNQaKOjwmWF5++WUAwJ49ex74/PHjx3Hx4kWcOHECer0ecXFx2LBhA1566SWsX78eGo2mG6v1Pp4WMAwUdfWYs0LFxcUYNWoU9Hq9dV5SUhLMZjMuXOi4i22xWGA2m20mctzx9+Pc+qB19/p6Co/psXTFaDTahAoA62Oj0djhcjk5OdbeEMnjbj0Yhkn3cmmPZdWqVfDx8el0unTpkqo1ZGdnw2QyWaeqqipVt+dtXN1DcPX2vZVLeywrV67E4sWLO20zePBgu9ZlMBhw9uxZm3m1tbXW5zqi1Wqh1Wrt2gY5ru3BrVZPhiHiHlwaLOHh4QgPD5eyrvj4eGzcuBE3b95EREQEAKCwsBDBwcEYPny4lG2QPLKChkHinjxmjOXatWv473//i2vXrqG5uRllZWUAgNjYWAQGBmL69OkYPnw4Fi5ciM2bN8NoNGLNmjVIT09nj8QDMCB6Fo8JlrVr12Lv3r3Wx6NHjwYAfPzxx5g8eTJ69eqFo0ePIi0tDfHx8ejTpw+Sk5P5w2lELsCf/2jD23/+g6gj/PkPInIpBgsRScdgISLpGCxEJB2DhYikY7AQkXQMFiKSjsFCRNIxWIhIOgYLEUnHYCEi6RgsRCQdg4WIpGOwEJF0DBYiko7BQkTSMViISDoGCxFJx2AhIukYLEQkHYOFiKRjsBCRdAwWIpKOwUJE0jFYiEg6BgsRScdgISLpGCxEJB2DhYik84hguXr1KpYuXYqYmBgEBATgkUcewbp169DY2GjT7osvvsCTTz4Jf39/REVFYfPmzS6qmMi7PeTqAuxx6dIltLS0YNeuXYiNjUV5eTlSUlJw9+5dbNmyBQBgNpsxffp0JCYm4vXXX8f58+exZMkShISEYNmyZS5+BUTexSOCZcaMGZgxY4b18eDBg1FRUYG8vDxrsOzbtw+NjY3Iz8+HRqPBiBEjUFZWhldffZXBQtTNPOKj0IOYTCaEhYVZHxcXF2PSpEnQaDTWeUlJSaioqMDt27c7XI/FYoHZbLaZiMg5HhkslZWV2L59O5YvX26dZzQaodfrbdq1PjYajR2uKycnBzqdzjpFRUWpUzSRF3FpsKxatQo+Pj6dTpcuXbJZprq6GjNmzMC8efOQkpLidA3Z2dkwmUzWqaqqyul1Enk7l46xrFy5EosXL+60zeDBg61/19TUYMqUKUhISMAbb7xh085gMKC2ttZmXutjg8HQ4fq1Wi20Wq3CyomoMy4NlvDwcISHh9vVtrq6GlOmTMGYMWNQUFAAX1/bzlZ8fDxWr16NpqYm+Pn5AQAKCwsxdOhQhIaGSq+diDrmEWMs1dXVmDx5MqKjo7FlyxbU1dXBaDTajJ0sWLAAGo0GS5cuxYULF3Dw4EH84Q9/QFZWlgsrJ/JOHnG6ubCwEJWVlaisrMSAAQNsnhNCAAB0Oh2OHz+O9PR0jBkzBv369cPatWt5qpnIBXxE65FJAL75op1Op0PSL2tx+esBXS9A5CWGhZrRZDHjw1f0MJlMCA4O7rCtR3wUIiLPwmAhIukYLEQkHYOFiKRjsBCRdAwWIpKOwUJE0jFYiEg6BgsRScdgISLpGCxEJJ1HXIToKsNCeZtKIkcwWNpovSbzvqXBxZUQuZ/W46Kra5cZLG00NHyz44q2xbq4EiL31dDQAJ1O1+HzvG1CGy0tLaipqUFQUBB8fHycXp/ZbEZUVBSqqqo6vcycHoz7zzmy958QAg0NDYiMjGx3F8fvYo+lDV9f33Y3k5IhODiYB4YTuP+cI3P/ddZTacWzQkQkHYOFiKRjsKhMq9Vi3bp1/IkRB3H/OcdV+4+Dt0QkHXssRCQdg4WIpGOwEJF0DBYiko7BooKrV69i6dKliImJQUBAAB555BGsW7cOjY2NNu2++OILPPnkk/D390dUVBQ2b97soord044dOzBo0CD4+/tj/PjxOHv2rKtLcks5OTkYO3YsgoKCEBERgTlz5qCiosKmzb1795Ceno6+ffsiMDAQc+fORW1trXpFCZLugw8+EIsXLxYffvihuHz5snj33XdFRESEWLlypbWNyWQSer1e/PSnPxXl5eVi//79IiAgQOzatcuFlbuPAwcOCI1GI/Lz88WFCxdESkqKCAkJEbW1ta4uze0kJSWJgoICUV5eLsrKysSsWbNEdHS0uHPnjrVNamqqiIqKEkVFRaKkpEQ88cQTIiEhQbWaGCzdZPPmzSImJsb6eOfOnSI0NFRYLBbrvJdeekkMHTrUFeW5nXHjxon09HTr4+bmZhEZGSlycnJcWJVnuHnzpgAgTp48KYQQor6+Xvj5+YlDhw5Z2/zrX/8SAERxcbEqNfCjUDcxmUwICwuzPi4uLsakSZOg0Wis85KSklBRUYHbt2+7okS30djYiNLSUiQmJlrn+fr6IjExEcXFxS6szDOYTCYAsP6/lZaWoqmpyWZ/Dhs2DNHR0artTwZLN6isrMT27duxfPly6zyj0Qi9Xm/TrvWx0Wjs1vrcza1bt9Dc3PzA/ePt+6YrLS0tyMzMxIQJEzBy5EgA3/w/aTQahISE2LRVc38yWBRYtWoVfHx8Op0uXbpks0x1dTVmzJiBefPmISUlxUWVk7dIT09HeXk5Dhw44NI6eNsEBVauXInFixd32mbw4MHWv2tqajBlyhQkJCTgjTfesGlnMBjajcq3PjYYDHIK9lD9+vVDr169Hrh/vH3fdCYjIwNHjx7FqVOnbG79YTAY0NjYiPr6eptei6r7U5WRGxLXr18XQ4YMEc8++6y4f/9+u+dbB28bGxut87Kzszl4+//GjRsnMjIyrI+bm5vFww8/zMHbB2hpaRHp6ekiMjJS/Pvf/273fOvg7eHDh63zLl26pOrgLYNFBdevXxexsbFi2rRp4vr16+LGjRvWqVV9fb3Q6/Vi4cKFory8XBw4cED07t2bp5v/34EDB4RWqxV79uwRFy9eFMuWLRMhISHCaDS6ujS3k5aWJnQ6nfjkk09s/te+/vpra5vU1FQRHR0tPvroI1FSUiLi4+NFfHy8ajUxWFRQUFAgADxw+q5z586JiRMnCq1WKx5++GHxu9/9zkUVu6ft27eL6OhoodFoxLhx48Tp06ddXZJb6uh/raCgwNrmf//7n3jhhRdEaGio6N27t/jJT35i80YnG2+bQETS8awQEUnHYCEi6RgsRCQdg4WIpGOwEJF0DBYiko7BQkTSMVjIZa5evWq9eDMuLk7Vbe3Zs8e6rczMTFW3RQwWcgMnTpxAUVGRqtuYP38+bty4gfj4eFW3Q9/g1c3kcn379kXfvn1V3UZAQAACAgJsbqxF6mGPhaSoq6uDwWDApk2brPM+++wzaDQah3oj+fn5GDFiBLRaLfr374+MjAzrcz4+Pti1axdmz56N3r1749FHH0VxcTEqKysxefJk9OnTBwkJCbh8+bKU10bKMVhIivDwcOTn52P9+vUoKSlBQ0MDFi5ciIyMDEybNk3RuvLy8pCeno5ly5bh/PnzeO+99xAbG2vTZsOGDVi0aBHKysowbNgwLFiwAMuXL0d2djZKSkoghLAJI+pmql3eSF7phRdeEN/73vfEggULxKhRo8S9e/c6bHvlyhUBQHz++ec28yMjI8Xq1as7XA6AWLNmjfVxcXGxACB2795tnbd//37h7+/fbtkf/vCH4he/+IX9L4gcwh4LSbVlyxbcv38fhw4dwr59+6DVahUtf/PmTdTU1HTZy3nsscesf7feG3fUqFE28+7duwez2axo+yQHg4Wkunz5MmpqatDS0oKrV68qXj4gIMCudn5+fta/fXx8OpzX0tKiuAZyHoOFpGlsbMRzzz2H+fPnY8OGDfjZz36GmzdvKlpHUFAQBg0apPrpZ1IXTzeTNKtXr4bJZMK2bdsQGBiI999/H0uWLMHRo0cVrWf9+vVITU1FREQEZs6ciYaGBvzjH//Aiy++qFLlJBt7LCTFJ598gtzcXLz55psIDg6Gr68v3nzzTXz66afIy8tTtK7k5GTk5uZi586dGDFiBGbPno0vv/xSpcpJDbw1JbnM1atXERMTg88//1z1r/S3mjx5MuLi4pCbm9st2/NW7LGQyyUkJCAhIUHVbezbtw+BgYH49NNPVd0OfYM9FnKZ+/fvW88cabVaREVFqbathoYG6w+ghYSEoF+/fqptixgsRKQCfhQiIukYLEQkHYOFiKRjsBCRdAwWIpKOwUJE0jFYiEg6BgsRScdgISLp/g9s4z7dzvcEtwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 258.065x259.74 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model.plot(color_by='cell')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By calling `Model.differentiate_mats` a new U235 material will be created for one of the cells in the interior of the pin. By making the same query for materials and re-plotting the model we can see the effect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.differentiate_mats()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{3: Material\n",
+       " \tID             =\t3\n",
+       " \tName           =\tfuel\n",
+       " \tTemperature    =\tNone\n",
+       " \tDensity        =\t11 [g/cc]\n",
+       " \tVolume         =\tNone [cm^3]\n",
+       " \tDepletable     =\tTrue\n",
+       " \tS(a,b) Tables  \n",
+       " \tNuclides       \n",
+       " \tU235           =\t1.0          [ao],\n",
+       " 4: Material\n",
+       " \tID             =\t4\n",
+       " \tName           =\tfuel\n",
+       " \tTemperature    =\tNone\n",
+       " \tDensity        =\t11 [g/cc]\n",
+       " \tVolume         =\tNone [cm^3]\n",
+       " \tDepletable     =\tTrue\n",
+       " \tS(a,b) Tables  \n",
+       " \tNuclides       \n",
+       " \tU235           =\t1.0          [ao],\n",
+       " 41: Material\n",
+       " \tID             =\t41\n",
+       " \tName           =\twater\n",
+       " \tTemperature    =\tNone\n",
+       " \tDensity        =\t1.0 [g/cc]\n",
+       " \tVolume         =\tNone [cm^3]\n",
+       " \tDepletable     =\tFalse\n",
+       " \tS(a,b) Tables  \n",
+       " \tS(a,b)         =\t('c_H_in_H2O', 1.0)\n",
+       " \tNuclides       \n",
+       " \tH1             =\t2.0          [ao]\n",
+       " \tO16            =\t1.0          [ao]}"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dag_univ.get_all_materials()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: xlabel='x [cm]', ylabel='y [cm]'>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAEHCAYAAACgHI2PAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAIrtJREFUeJzt3X1UVHX+B/D3gMwAAgPIw4BCYKBGkSSpC5WiciQ329hct4ejgZkagbuInZOkm/5yk9bcFSufOpvaeipNO7mtlUYUaEqaJCSVFC4IAcNDyQxqPAj394fL5IDIDMzMnXvn/TrnnuPcuXPvZ65z3/Ple+98r0IQBAFERCRbTmIXQERE1sWgJyKSOQY9EZHMMeiJiGSOQU9EJHMMeiIimWPQExHJHIOeiEjmholdgL3p7u5GXV0dPD09oVAoxC6HyK4IgoDW1lYEBwfDyWngdmJ3dzc6OjpsUJljcXFxgbOzs8nLM+h7qaurQ0hIiNhlENm1mpoajBo16obLdHR0oLKyEt3d3TaqyrF4e3tDo9GY1CBl0Pfi6ekJ4OoH2cvLS+RqiOyLXq9HSEiI4TjpjyAIqK+vh7OzM0JCQkxq/ZNpBEHA5cuX0djYCAAICgoa8DUM+l56vh29vLwY9ET9GKgVeeXKFVy+fBnBwcFwd3e3UVWOw83NDQDQ2NiIgICAAbtx+DVLRBbX1dUFAFAqlSJXIl89X6CdnZ0DLsugJyKr4QUN1mPOvmXQExHJHPvoichmqnXVaL7cbLPt+bn7IVQdavLygiBgyZIl2L9/Py5cuIDTp08jJiZmSDWsWbMGBw4cQElJyZDWMxQMeiKyiWpdNca+OhZtV9pstk3XYa4ozyg3OewPHTqEXbt2oaCgAKNHj4afn5+VK7QNBj0R2UTz5WabhjwAtF1pQ/PlZpOD/ty5cwgKCkJ8fLyVK7Mt9tETEQFITU3F0qVLUV1dDYVCgbCwMISFhSE3N9douZiYGKxZs8bwuKWlBU888QT8/f3h5eWF6dOno7S01LbFD4BBT0QEYNOmTXj++ecxatQo1NfX48svvzTpdXPnzkVjYyM++ugjFBcXY8KECZgxYwZ+/vlnK1dsOgY9EREAtVoNT09PODs7Q6PRwN/ff8DXfP755zh58iT27duHO++8E5GRkdiwYQO8vb2xf/9+G1RtGvbRExENUmlpKS5evIgRI0YYzf/ll19w7tw5karqi0FPRNQPJycnCIJgNO/aX6JevHgRQUFBKCgo6PNab29vK1dnOgY9EVE//P39UV9fb3is1+tRWVlpeDxhwgRotVoMGzYMYWFhIlRoGvbRExH1Y/r06di9ezeOHj2KM2fOICUlxWgAscTERMTFxSE5ORkff/wxqqqqcPz4caxcuRKnTp0SsXJjkgn6nJwcTJw4EZ6enggICEBycjLKy8uNlmlra0N6ejpGjBgBDw8PzJkzBw0NDSJVTETX8nP3g+swV5tu03WYK/zcB/+jp+zsbEydOhWzZ8/Gfffdh+TkZNx8882G5xUKBT788ENMmTIFCxYswJgxY/Dwww/j/PnzCAwMtMRbsAiF0LsDyk7de++9ePjhhzFx4kRcuXIFzz77LMrKyvDtt99i+PDhAIC0tDR88MEH2LVrF9RqNTIyMuDk5IRjx46ZvB29Xg+1Wg2dTsdhiol6MfX4aGtrQ2VlJcLDw+Hq+mu42/sQCFLS3z6+HskEfW9NTU0ICAhAYWEhpkyZAp1OB39/f7z11lv4wx/+AAA4e/YsbrnlFhQVFeE3v/mNSetl0BP1b6hBT5Zjzj6WTNdNbzqdDgDg6+sLACguLkZnZycSExMNy4wbNw6hoaEoKirqdz3t7e3Q6/VGExGRnEgy6Lu7u5GZmYm77roLt912GwBAq9VCqVT2uaQpMDAQWq2233Xl5ORArVYbJt4vlojkRpJBn56ejrKyMuzZs2fI68rOzoZOpzNMNTU1FqiQiMh+SO46+oyMDBw8eBBHjhwxugu9RqNBR0cHWlpajFr1DQ0N0Gg0/a5PpVJBpVJZs2QiIlFJpkUvCAIyMjLw3nvv4dNPP0V4eLjR87GxsXBxcUF+fr5hXnl5OaqrqxEXF2frcomI7IZkWvTp6el466238O9//xuenp6Gfne1Wg03Nzeo1WosXLgQWVlZ8PX1hZeXF5YuXYq4uDiTr7ghIpIjyQT91q1bAQAJCQlG83fu3InU1FQAwMaNG+Hk5IQ5c+agvb0dSUlJ2LJli40rJSKyL5IJelMu93d1dcXmzZuxefNmG1RERCQNkgl6IpK+6mqg2XY/jIWfHxAqzx/GmoVBT0Q2UV0NjB0LtNnwtrGurkB5uXhhn5CQgJiYmD63I7Q1yVx1Q0TS1txs25AHrm7Pln9BWEtHR8eQXs+gJyL6n4MHD8Lb2xtdXV0AgJKSEigUCqxYscKwzBNPPIF58+bhp59+wiOPPIKRI0fC3d0d0dHRePvttw3LpaamorCwEJs2bYJCoYBCoUBVVRUAoKysDLNmzYKHhwcCAwMxf/58NF/zjZSQkICMjAxkZmbCz88PSUlJQ3pfDHoiov+555570NraitOnTwMACgsL4efnZ3QHqcLCQiQkJKCtrQ2xsbH44IMPUFZWhsWLF2P+/Pk4efIkgKs3G4+Li8OiRYtQX1+P+vp6hISEoKWlBdOnT8cdd9yBU6dO4dChQ2hoaMAf//hHo1reeOMNKJVKHDt2DNu2bRvS+2IfPRHR/6jVasTExKCgoAB33nknCgoKsGzZMvzf//0fLl68CJ1Oh4qKCkydOhUjR47E008/bXjt0qVLcfjwYbzzzjuYNGkS1Go1lEol3N3djX6d/+qrr+KOO+7AunXrDPN27NiBkJAQfP/99xgzZgwAIDIyEuvXr7fI+2KLnojoGlOnTkVBQQEEQcDRo0fx4IMP4pZbbsHnn3+OwsJCBAcHIzIyEl1dXVi7di2io6Ph6+sLDw8PHD58GNXV1Tdcf2lpKT777DN4eHgYpnHjxgGA0Q3FY2NjLfae2KInIrpGQkICduzYgdLSUri4uGDcuHFISEhAQUEBLly4gKlTpwIAXnrpJWzatAm5ubmIjo7G8OHDkZmZOeCJ04sXL+L+++/H3/72tz7PBQUFGf7dc0MlS2DQExFdo6effuPGjYZQT0hIwIsvvogLFy5g+fLlAIBjx47hgQcewLx58wBcHT79+++/R1RUlGFdSqXScGK3x4QJE/Duu+8iLCwMw4bZJoLZdUNEdA0fHx/cfvvtePPNNw1DrkyZMgVfffUVvv/+e0P4R0ZGIi8vD8ePH8d3332HJUuW9LlHdVhYGE6cOIGqqio0Nzeju7sb6enp+Pnnn/HII4/gyy+/xLlz53D48GEsWLCgz5eCpTDoicgm/Pyu/oDJllxdr27XXFOnTkVXV5ch6H19fREVFQWNRoOxY8cCAFatWoUJEyYgKSkJCQkJ0Gg0SE5ONlrP008/DWdnZ0RFRcHf3x/V1dUIDg7GsWPH0NXVhZkzZyI6OhqZmZnw9vaGk5N1Ilmy94y1Ft4zlqh/Q745OIdAsBhz7hnLPnoispnQUPkGrz1j1w0Rkcwx6ImIZI5BT0Qkcwx6IrIaXuthPebsWwY9EVmcs7MzgKEPr0v9u3z5MgDAxcVlwGV51Q0RWdywYcPg7u6OpqYmuLi4WO36cEckCAIuX76MxsZGeHt7G75Ub4RBT0QWp1AoEBQUhMrKSpw/f17scmTJ29vbaFTMG2HQE5FVKJVKREZGsvvGClxcXExqyfdg0BOR1Tg5OQ34q02yPnacERHJHIOeiEjmGPRERDLHoCcikjkGPRGRzDHoiYhkjkFPRCRzkgr6I0eO4P7770dwcDAUCgUOHDhg9LwgCHjuuecQFBQENzc3JCYm4ocffhCnWDKLQjG4iYgGJqmgv3TpEsaPH4/Nmzdf9/n169fj5ZdfxrZt23DixAkMHz4cSUlJaGtrs3GlNBBLBTaDn2hgkvpl7KxZszBr1qzrPicIAnJzc7Fq1So88MADAIB//etfCAwMxIEDB/Dwww/bslTqxVYh3Hs7HCWXSGIt+huprKyEVqtFYmKiYZ5arcbkyZNRVFTU7+va29uh1+uNJrIcsVvaYm+fyB7IJui1Wi0AIDAw0Gh+YGCg4bnrycnJgVqtNkwhISFWrdNR2FvA2ls9RLYkm6AfrOzsbOh0OsNUU1MjdkmSZu+Bau/1EVmDpProb6RnXOaGhgYEBQUZ5jc0NCAmJqbf16lUKqhUKmuXJ3tSC8+eetmHT45ANi368PBwaDQa5OfnG+bp9XqcOHECcXFxIlYmb1JvIUu9fiJTSKpFf/HiRVRUVBgeV1ZWoqSkBL6+vggNDUVmZib++te/IjIyEuHh4fjLX/6C4OBgJCcni1e0jFk6IGs3Zpu1/MhlORbbtkLB1j3Jl0KQ0G3aCwoKMG3atD7zU1JSsGvXLgiCgNWrV+O1115DS0sL7r77bmzZsgVjxowxeRt6vR5qtRo6nQ5eXl6WLF9WLBHy5gb7QCwR/NI5GsTB40OaJBX0tsAP8o0NNeAtHe79GWro86i4Ph4f0iSprhsS11BC3lYB33t7gw18duWQnDDoySSDDXlbB3x/2x9M4DPsSS4Y9DSgwYS82AHf22ADn2FPcsCgpxsyN+TtLeB7G0zgM+xJ6mRzHT1ZntxC/lrm1spr7UnK2KIni7BUyJcePGzScuNnJw15W7Ubsy16LT6RveLllb3w8rGrzGnBDiXkTQ32gQwl+M0Je0c/Wnh8SBODvhd+kK0f8pYK9/4MJvQZ9qbh8SFNDPpeHP2DbM2Qt3bA92Zu4DPsB+box4dU8WQsDYq9h/xgtimlk8lE5mCLvhdHbrGY2po3JxDFCPjrMad1b2rL3hGPHEc+PqSMLXoyixRDHjCvFrbsSW5MatFnZWWZveJVq1bB19d3UEWJyVFbLKa05qUa8teydMve0Vr1jnp8SJ1J19Hn5uYiLi4OSqXSpJV+/vnnyMjIkGTQ09DZa8gDV2uzxDX4RFJiUoveyckJWq0WAQEBJq3U09MTpaWlGD169JALtDVHbLFYsjVvzyF/LVPDnq16Y454fMiBSX30O3fuhFqtNnml27dvR2Bg4KCLImmSSsgD0qqVaKh41U0vjtZisVRrXqrBaUrLnq36Xzna8SEXQxrr5uLFi+ju7jaax/98IiL7YvbllZWVlbjvvvswfPhwqNVq+Pj4wMfHB97e3vDx8bFGjWQljt6aB0yr3ZR9wNEtyZ6Z3aKfN28eBEHAjh07EBgYCAU/4Q5NyiHfg1fikNyZHfSlpaUoLi7G2LFjrVEP2RH+cOhXHNKYpMzsrpuJEyeipqbGGrWQxMihNd9DTu+FqDezW/T//Oc/8eSTT6K2tha33XYbXFxcjJ6//fbbLVYcWQ973CyPtxwke2V20Dc1NeHcuXNYsGCBYZ5CoYAgCFAoFOjq6rJogSQOdtv0xe4bkiqzg/7xxx/HHXfcgbfffpsnYx2YHLs6eFKW5MrsoD9//jzef/99REREWKMeIiKyMLNPxk6fPh2lpaXWqIVshH+EWQ/3Ldkjs1v0999/P5YtW4YzZ84gOjq6z8nY3/3udxYrjsTB/vn+sZ+epMjssW6cnPr/I0AOJ2MdYSyPgVqdAwW9HPvnrzVQP/1AQS/nK28c4fiQI7O7brq7u/ud7CXkN2/ejLCwMLi6umLy5Mk4efKk2CUREYlGdrcS3Lt3L7KysrB69Wp89dVXGD9+PJKSktDY2Ch2aUREojA76P/0pz/h5Zdf7jP/1VdfRWZmpiVqGpJ//OMfWLRoERYsWICoqChs27YN7u7u2LFjh9ilERGJwuygf/fdd3HXXXf1mR8fH4/9+/dbpKjB6ujoQHFxMRITEw3znJyckJiYiKKiouu+pr29HXq93mgiIpITs4P+p59+uu7dpry8vNDc3GyRogarubkZXV1dfe5uFRgYCK1We93X5OTkQK1WG6aQkBBblEpEZDNmB31ERAQOHTrUZ/5HH30kyXvEZmdnQ6fTGSYO2EZEcmP2dfRZWVnIyMhAU1MTpk+fDgDIz8/H3//+d+Tm5lq6PrP4+fnB2dkZDQ0NRvMbGhqg0Wiu+xqVSgWVSmWL8oiIRDGosW7a29vxwgsvYO3atQCAsLAwbN26FY899pjFCzSHUqlEbGws8vPzkZycDODq5aD5+fnIyMgQtTYiIrEM6p6xaWlpSEtLQ1NTE9zc3ODh4WHpugYtKysLKSkpuPPOOzFp0iTk5ubi0qVLRqNtEhE5kiHdHNzf399SdVjMQw89hKamJjz33HPQarWIiYnBoUOH+pygpcEbPztJtr+O5eiVJEcmnYydMGECLly4YPJK7777btTW1g66qKHKyMjA+fPn0d7ejhMnTmDy5Mmi1SJFHMulf9w3JEUmtehLSkpQWloKX19fk1ZaUlKC9vb2IRVG1iMIHGXRWuQ8zg1Jl8ldNzNmzICp45/xZiRERPbDpKCvrKw0e8WjRo0y+zUkHXLsp2f/PMmVSUF/0003WbsOsjMjl+VwXPpe2D9PUiW70SvJNOxLtjzuU7JXDHoaNDl1dcjpvRD1xqCnfrGr4lfcFyRlDHoaEjm0hOXwHohuxOygT0lJwZEjR6xRC9mYKX3KprRkpRyUptRuyj5g/zzZM7ODXqfTITExEZGRkVi3bp2ov4AlIqKBmR30Bw4cQG1tLdLS0rB3716EhYVh1qxZ2L9/Pzo7O61RI1mRI7fq2ZonRzGoPnp/f39kZWWhtLQUJ06cQEREBObPn4/g4GAsW7YMP/zwg6XrJAmQUthLqVaioRrSydj6+nrk5eUhLy8Pzs7O+O1vf4szZ84gKioKGzdutFSNZGWWatUD0ghQU2tka57kwuyg7+zsxLvvvovZs2fjpptuwr59+5CZmYm6ujq88cYb+OSTT/DOO+/g+eeft0a9JAH2HPb2XBuRtZg9Hn1QUBC6u7vxyCOP4OTJk4iJiemzzLRp0+Dt7W2B8shWTBnR0pxhEexxLBxzQp6teZIThWDqkJT/s3v3bsydOxeurq7WqklUer0earUaOp0OXl5eYpdjU6YOOmrOGDj2EvaWDnnAMYPekY8PKTM76OXO0T/I1gh7QLzAN7erhiF/Y45+fEgVfxlLg2LukABi9I1bK+SJpIYt+l7YYjHv7lODGcrY2q37wXypmBPyjnzE8PiQJgZ9L/wgX2XtsO9hqdAfyl8MDHnT8fiQJgZ9L/wg/8pWYX8tU4PfUl1BDHnz8PiQJgZ9L/wg/8rcW/9K7Y5U5vbJ80jh8SFVPBlL/TI32KR0MpMhT47E7B9MkWMx5YdU1+oJUHtt3Q/my4ghT1LHoKcBmRv2gP0F/mD/2mDIkxww6Mkkgwl7QPzAH0p3EkOe5IJBTyYbbNgDtg/8oZ4vYMiTnDDoySw9ATjUwAcsH/qWOBnMgCc5YtDToAyldd+jdzCbG/yWvsqHIU9yJZmgf+GFF/DBBx+gpKQESqUSLS0tfZaprq5GWloaPvvsM3h4eCAlJQU5OTkYNkwyb1NSLBH21xLz8kyGPMmZZBKwo6MDc+fORVxcHF5//fU+z3d1deG+++6DRqPB8ePHUV9fj8ceewwuLi5Yt26dCBU7hqF25YiNAU+OQHK/jN21axcyMzP7tOg/+ugjzJ49G3V1dQgMDAQAbNu2Dc888wyampqgVCpNWj9/+Tc0Ugl8aX3q7QePD2mSzS9ji4qKEB0dbQh5AEhKSoJer8c333zT7+va29uh1+uNJho8QbDvELX3+oisQTZBr9VqjUIegOGxVqvt93U5OTlQq9WGKSQkxKp1Ogp7C1R7q4fIlkQN+hUrVkChUNxwOnv2rFVryM7Ohk6nM0w1NTVW3Z6jETtgxd4+kT0Q9WTs8uXLkZqaesNlRo8ebdK6NBoNTp48aTSvoaHB8Fx/VCoVVCqVSdugwesdttbqy2eoE/UlatD7+/vD39/fIuuKi4vDCy+8gMbGRgQEBAAA8vLy4OXlhaioKItsgyzHUsHPYCcamGQur6yursbPP/+M6upqdHV1oaSkBAAQEREBDw8PzJw5E1FRUZg/fz7Wr18PrVaLVatWIT09nS12CWBgE1mPZC6vTE1NxRtvvNFn/meffYaEhAQAwPnz55GWloaCggIMHz4cKSkpePHFF836wRQvHyPqH48PaZJM0NsKP8hE/ePxIU2yubySiIiuj0FPRCRzDHoiIplj0BMRyRyDnohI5hj0REQyx6AnIpI5Bj0Rkcwx6ImIZI5BT0Qkcwx6IiKZY9ATEckcg56ISOYY9EREMsegJyKSOQY9EZHMMeiJiGSOQU9EJHMMeiIimWPQExHJHIOeiEjmGPRERDLHoCcikjkGPRGRzDHoiYhkjkFPRCRzDHoiIplj0BMRyRyDnohI5iQR9FVVVVi4cCHCw8Ph5uaGm2++GatXr0ZHR4fRcl9//TXuueceuLq6IiQkBOvXrxepYiIi+zFM7AJMcfbsWXR3d2P79u2IiIhAWVkZFi1ahEuXLmHDhg0AAL1ej5kzZyIxMRHbtm3DmTNn8Pjjj8Pb2xuLFy8W+R0QEYlHIQiCIHYRg/HSSy9h69at+O9//wsA2Lp1K1auXAmtVgulUgkAWLFiBQ4cOICzZ8+avF69Xg+1Wg2dTgcvLy+r1E4kVTw+pEkSXTfXo9Pp4Ovra3hcVFSEKVOmGEIeAJKSklBeXo4LFy70u5729nbo9XqjiYhITiQZ9BUVFXjllVewZMkSwzytVovAwECj5Xoea7XafteVk5MDtVptmEJCQqxTNBGRSEQN+hUrVkChUNxw6t3tUltbi3vvvRdz587FokWLhlxDdnY2dDqdYaqpqRnyOomI7ImoJ2OXL1+O1NTUGy4zevRow7/r6uowbdo0xMfH47XXXjNaTqPRoKGhwWhez2ONRtPv+lUqFVQqlZmVExFJh6hB7+/vD39/f5OWra2txbRp0xAbG4udO3fCycn4j5G4uDisXLkSnZ2dcHFxAQDk5eVh7Nix8PHxsXjtRERSIYk++traWiQkJCA0NBQbNmxAU1MTtFqtUd/7o48+CqVSiYULF+Kbb77B3r17sWnTJmRlZYlYORGR+CRxHX1eXh4qKipQUVGBUaNGGT3Xc3WoWq3Gxx9/jPT0dMTGxsLPzw/PPfccr6EnIocn2evorYXXCRP1j8eHNEmi64aIiAaPQU9EJHMMeiIimWPQExHJHIOeiEjmGPRERDLHoCcikjkGPRGRzDHoiYhkjkFPRCRzDHoiIplj0BMRyZwkRq+0pZ4x3njvWKK+eo4LjoUoLQz6XlpbWwGA944luoHW1lao1WqxyyATcZjiXrq7u1FXVwdPT08oFIohr0+v1yMkJAQ1NTUc1nUQuP+GxtL7TxAEtLa2Ijg4uM9d3sh+sUXfi5OTU5+bm1iCl5cXg2oIuP+GxpL7jy156eFXMhGRzDHoiYhkjkFvZSqVCqtXr4ZKpRK7FEni/hsa7j8CeDKWiEj22KInIpI5Bj0Rkcwx6ImIZI5BT0Qkcwx6K6iqqsLChQsRHh4ONzc33HzzzVi9ejU6OjqMlvv6669xzz33wNXVFSEhIVi/fr1IFdunzZs3IywsDK6urpg8eTJOnjwpdkl2KScnBxMnToSnpycCAgKQnJyM8vJyo2Xa2tqQnp6OESNGwMPDA3PmzEFDQ4NIFZOtMeit4OzZs+ju7sb27dvxzTffYOPGjdi2bRueffZZwzJ6vR4zZ87ETTfdhOLiYrz00ktYs2YNXnvtNRErtx979+5FVlYWVq9eja+++grjx49HUlISGhsbxS7N7hQWFiI9PR1ffPEF8vLy0NnZiZkzZ+LSpUuGZZYtW4b//Oc/2LdvHwoLC1FXV4cHH3xQxKrJpgSyifXr1wvh4eGGx1u2bBF8fHyE9vZ2w7xnnnlGGDt2rBjl2Z1JkyYJ6enphsddXV1CcHCwkJOTI2JV0tDY2CgAEAoLCwVBEISWlhbBxcVF2Ldvn2GZ7777TgAgFBUViVUm2RBb9Dai0+ng6+treFxUVIQpU6ZAqVQa5iUlJaG8vBwXLlwQo0S70dHRgeLiYiQmJhrmOTk5ITExEUVFRSJWJg06nQ4ADJ+34uJidHZ2Gu3PcePGITQ0lPvTQTDobaCiogKvvPIKlixZYpin1WoRGBhotFzPY61Wa9P67E1zczO6urquu38cfd8MpLu7G5mZmbjrrrtw2223Abj6eVIqlfD29jZalvvTcTDozbBixQooFIobTmfPnjV6TW1tLe69917MnTsXixYtEqlychTp6ekoKyvDnj17xC6F7AiHKTbD8uXLkZqaesNlRo8ebfh3XV0dpk2bhvj4+D4nWTUaTZ+rHnoeazQayxQsUX5+fnB2dr7u/nH0fXMjGRkZOHjwII4cOWI01LZGo0FHRwdaWlqMWvXcn46DQW8Gf39/+Pv7m7RsbW0tpk2bhtjYWOzcubPPTRri4uKwcuVKdHZ2wsXFBQCQl5eHsWPHwsfHx+K1S4lSqURsbCzy8/ORnJwM4GqXRH5+PjIyMsQtzg4JgoClS5fivffeQ0FBAcLDw42ej42NhYuLC/Lz8zFnzhwAQHl5OaqrqxEXFydGyWRrYp8NlqMff/xRiIiIEGbMmCH8+OOPQn19vWHq0dLSIgQGBgrz588XysrKhD179gju7u7C9u3bRazcfuzZs0dQqVTCrl27hG+//VZYvHix4O3tLWi1WrFLsztpaWmCWq0WCgoKjD5rly9fNizz5JNPCqGhocKnn34qnDp1SoiLixPi4uJErJpsiUFvBTt37hQAXHe6VmlpqXD33XcLKpVKGDlypPDiiy+KVLF9euWVV4TQ0FBBqVQKkyZNEr744guxS7JL/X3Wdu7caVjml19+EZ566inBx8dHcHd3F37/+98bNTxI3jhMMRGRzPGqGyIimWPQExHJHIOeiEjmGPRERDLHoCcikjkGPRGRzDHoiYhkjkFPoqmqqjIMBhcTE2PVbe3atcuwrczMTKtui8jeMOhJdJ988gny8/Otuo2HHnoI9fX1HNuFHBIHNSPRjRgxAiNGjLDqNtzc3ODm5mZ0oxciR8EWPVlEU1MTNBoN1q1bZ5h3/PhxKJXKQbXWd+zYgVtvvRUqlQpBQUFGo1YqFAps374ds2fPhru7O2655RYUFRWhoqICCQkJGD58OOLj43Hu3DmLvDciqWPQk0X4+/tjx44dWLNmDU6dOoXW1lbMnz8fGRkZmDFjhlnr2rp1K9LT07F48WKcOXMG77//PiIiIoyWWbt2LR577DGUlJRg3LhxePTRR7FkyRJkZ2fj1KlTEASBQxoT9RB5UDWSmaeeekoYM2aM8OijjwrR0dFCW1tbv8tWVlYKAITTp08bzQ8ODhZWrlzZ7+sACKtWrTI8LioqEgAIr7/+umHe22+/Lbi6uvZ57dSpU4U///nPpr8hIhlgi54sasOGDbhy5Qr27duHN998EyqVyqzXNzY2oq6ubsC/Am6//XbDv3vuLRsdHW00r62tDXq93qztE8kRg54s6ty5c6irq0N3dzeqqqrMfr2bm5tJy/XclQu42mff37zu7m6zayCSGwY9WUxHRwfmzZuHhx56CGvXrsUTTzyBxsZGs9bh6emJsLAwq19uSeRIeHklWczKlSuh0+nw8ssvw8PDAx9++CEef/xxHDx40Kz1rFmzBk8++SQCAgIwa9YstLa24tixY1i6dKmVKieSN7boySIKCgqQm5uL3bt3w8vLC05OTti9ezeOHj2KrVu3mrWulJQU5ObmYsuWLbj11lsxe/Zs/PDDD1aqnEj+eCtBEk1VVRXCw8Nx+vRpqw+B0CMhIQExMTHIzc21yfaI7AFb9CS6+Ph4xMfHW3Ubb775Jjw8PHD06FGrbofIHrFFT6K5cuWK4coclUqFkJAQq22rtbUVDQ0NAABvb2/4+flZbVtE9oZBT0Qkc+y6ISKSOQY9EZHMMeiJiGSOQU9EJHMMeiIimWPQExHJHIOeiEjmGPRERDLHoCcikrn/B3h2qKreTH5gAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 258.065x259.74 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model.plot(color_by='material', colors=material_colors, legend=True)"
+   ]
   }
  ],
  "metadata": {

--- a/cad-model-sync.ipynb
+++ b/cad-model-sync.ipynb
@@ -1,0 +1,547 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DAGMC Model Synchronization\n",
+    "\n",
+    "This notebook explores a feature of OpenMC that allows for the population of `DAGMCUniverses` with `DAGMCCell` objects that represent the cells generated in DAGMC simulations. These cells reflect the DAGMC model as-interpreted by OpenMC (including adjusted cell and material IDs). And, to an extent, changes to these objects will be reflected in the OpenMC simulatin (i.e. updated material assignments).\n",
+    "\n",
+    "This operation uses `Model.sync_dagmc_universes`, which requires that the model be initialized with `Model.init_lib`.\n",
+    "\n",
+    "In this notebook, we'll explore the use of this feature for a variety of purposes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image\n",
+    "import openmc\n",
+    "import math\n",
+    "from matplotlib import pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "openmc.config['cross_sections'] = '/home/pshriwise/data/xs/openmc/endfb-vii.1-hdf5/cross_sections.xml'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from warnings import warn\n",
+    "import openmc.lib\n",
+    "\n",
+    "if not openmc.lib._dagmc_enabled():\n",
+    "    warn(\"DAGMC is not enabled.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request\n",
+    "\n",
+    "fuel_pin_url = 'https://tinyurl.com/y3ugwz6w' # 1.2 MB\n",
+    "teapot_url = 'https://tinyurl.com/y4mcmc3u' # 29 MB\n",
+    "paramak_w_graveyard = 'https://tinyurl.com/y7w238th' # 18 MB\n",
+    "\n",
+    "def download(url, filename=\"dagmc.h5m\"):\n",
+    "    \"\"\"\n",
+    "    Helper function for retrieving dagmc models\n",
+    "    \"\"\"\n",
+    "    u = urllib.request.urlopen(url)\n",
+    "\n",
+    "    if u.status != 200:\n",
+    "        raise RuntimeError(\"Failed to download file.\")\n",
+    "\n",
+    "    # save file as dagmc.h5m\n",
+    "    with open(filename, 'wb') as f:\n",
+    "        f.write(u.read())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we'll bring in a simple DAGMC model of a fuel pin (see the other notebook on CAD-based geometry for additional information on this model).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "download(fuel_pin_url, 'fuel_pin.h5m')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    " # materials\n",
+    "u235 = openmc.Material(name=\"fuel\")\n",
+    "u235.add_nuclide('U235', 1.0, 'ao')\n",
+    "u235.set_density('g/cc', 11)\n",
+    "u235.id = 40\n",
+    "\n",
+    "water = openmc.Material(name=\"water\")\n",
+    "water.add_nuclide('H1', 2.0, 'ao')\n",
+    "water.add_nuclide('O16', 1.0, 'ao')\n",
+    "water.set_density('g/cc', 1.0)\n",
+    "water.add_s_alpha_beta('c_H_in_H2O')\n",
+    "water.id = 41\n",
+    "\n",
+    "materials = openmc.Materials([u235, water])\n",
+    "material_colors = {\n",
+    "    u235: 'green',\n",
+    "    water: 'blue'\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll create a DAGMC universe and bound it with CSG reflective planes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = openmc.Model()\n",
+    "\n",
+    "dag_univ = openmc.DAGMCUniverse(universe_id=5, filename='fuel_pin.h5m')\n",
+    "root_universe = dag_univ.bounded_universe(boundary_type='reflective')\n",
+    "\n",
+    "model.geometry = openmc.Geometry(root=root_universe)\n",
+    "model.materials = materials\n",
+    "model.settings.particles = 1000\n",
+    "model.settings.batches = 10\n",
+    "model.settings.inactive = 0\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point we have model we can run in OpenMC, but some of the functionality available in the Python API for models made entirely from CSG isn't available. For example, only one cell (the bounding cell) is found when calling `get_all_cells` on the geometry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: xlabel='x [cm]', ylabel='y [cm]'>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAEHCAYAAACgHI2PAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAIaBJREFUeJzt3X1UVHX+B/D3gMwAAjMgDwMJgUEaRZGkLlSKypHcbGNz3R6OBGZqBO4idjZJN/3lJq25K1amdja17VSadnJbK4so0JQ0SUgqKVwQAoaHkhnUeJC5vz9cZh0QmYGZuXMv79c59xznzn34zJV58+U73/lehSAIAoiISLZcxC6AiIjsi0FPRCRzDHoiIplj0BMRyRyDnohI5hj0REQyx6AnIpI5Bj0RkcyNErsAZ2M0GtHQ0ABvb28oFAqxyyFyKoIgoL29HSEhIXBxGbydaDQa0dXV5YDKRhY3Nze4urpavD2Dvo+GhgaEhoaKXQaRU6urq8PYsWOvuk1XVxeqq6thNBodVNXIotFooNVqLWqQMuj78Pb2BnDpB9nHx0fkaoici8FgQGhoqOl9MhBBENDY2AhXV1eEhoZa1PonywiCgAsXLqC5uRkAEBwcPOg+DPo+en87+vj4MOiJBjBYK/LixYu4cOECQkJC4Onp6aCqRg4PDw8AQHNzMwIDAwftxuGvWSKyuZ6eHgCAUqkUuRL56v0F2t3dPei2DHoishsOaLAfa64tg56ISObYR09EDlOrr0XrhVaHnc/f0x9h6jCLtxcEAUuWLMHevXtx9uxZnDhxArGxscOqYc2aNdi3bx/KysqGdZzhYNATkUPU6msx/qXx6LjY4bBzuo9yR2VWpcVhf+DAAezcuRNFRUUYN24c/P397VyhYzDoicghWi+0OjTkAaDjYgdaL7RaHPSnT59GcHAwEhIS7FyZY7GPnogIQHp6OpYuXYra2looFAqEh4cjPDwc+fn5ZtvFxsZizZo1psdtbW149NFHERAQAB8fH8yYMQPl5eWOLX4QDHoiIgCbNm3CM888g7Fjx6KxsRFffvmlRfvNmzcPzc3N+PDDD1FaWoqJEydi5syZ+Pnnn+1cseUY9EREANRqNby9veHq6gqtVouAgIBB9/n8889x7Ngx7NmzB7fddhuioqKwYcMGaDQa7N271wFVW4Z99EREQ1ReXo5z585hzJgxZut/+eUXnD59WqSq+mPQExENwMXFBYIgmK27/Juo586dQ3BwMIqKivrtq9Fo7Fyd5Rj0REQDCAgIQGNjo+mxwWBAdXW16fHEiROh0+kwatQohIeHi1ChZdhHT0Q0gBkzZuD111/HoUOHcPLkSaSlpZlNIJaUlIT4+HikpKTg448/Rk1NDY4cOYKVK1fi+PHjIlZuTjJBn5eXh0mTJsHb2xuBgYFISUlBZWWl2TYdHR3IzMzEmDFj4OXlhblz56KpqUmkionocv6e/nAf5e7Qc7qPcoe/59C/9JSbm4tp06Zhzpw5uPvuu5GSkoLrrrvO9LxCocAHH3yAqVOnYsGCBbj++uvxwAMP4MyZMwgKCrLFS7AJhdC3A8pJ3XXXXXjggQcwadIkXLx4EU899RQqKirw7bffYvTo0QCAjIwMvP/++9i5cyfUajWysrLg4uKCw4cPW3weg8EAtVoNvV7PaYqJ+rD0/dHR0YHq6mpERETA3f1/4e7sUyBIyUDX+EokE/R9tbS0IDAwEMXFxZg6dSr0ej0CAgLw5ptv4ne/+x0A4NSpU7jhhhtQUlKCX/3qVxYdl0FPNLDhBj3ZjjXXWDJdN33p9XoAgJ+fHwCgtLQU3d3dSEpKMm0zYcIEhIWFoaSkZMDjdHZ2wmAwmC1ERHIiyaA3Go3Izs7G7bffjptuugkAoNPpoFQq+w1pCgoKgk6nG/BYeXl5UKvVpoX3iyUiuZFk0GdmZqKiogK7du0a9rFyc3Oh1+tNS11dnQ0qJCJyHpIbR5+VlYX9+/fj4MGDZneh12q16OrqQltbm1mrvqmpCVqtdsDjqVQqqFQqe5ZMRCQqybToBUFAVlYW3n33XXz66aeIiIgwez4uLg5ubm4oLCw0rausrERtbS3i4+MdXS4RkdOQTIs+MzMTb775Jv71r3/B29vb1O+uVqvh4eEBtVqNhQsXIicnB35+fvDx8cHSpUsRHx9v8YgbIiI5kkzQb9myBQCQmJhotn7Hjh1IT08HAGzcuBEuLi6YO3cuOjs7kZycjJdfftnBlRIRORfJBL0lw/3d3d2xefNmbN682QEVERFJg2SCnoikr7YWaHXcF2Ph7w+EyfOLsVZh0BORQ9TWAuPHAx0OvG2suztQWSle2CcmJiI2Nrbf7QgdTTKjbohI2lpbHRvywKXzOfIvCHvp6uoa1v4MeiKi/9q/fz80Gg16enoAAGVlZVAoFFixYoVpm0cffRTz58/HTz/9hAcffBDXXHMNPD09ERMTg7feesu0XXp6OoqLi7Fp0yYoFAooFArU1NQAACoqKjB79mx4eXkhKCgIqampaL3sN1JiYiKysrKQnZ0Nf39/JCcnD+t1MeiJiP7rzjvvRHt7O06cOAEAKC4uhr+/v9kdpIqLi5GYmIiOjg7ExcXh/fffR0VFBRYvXozU1FQcO3YMwKWbjcfHx2PRokVobGxEY2MjQkND0dbWhhkzZuDWW2/F8ePHceDAATQ1NeH3v/+9WS2vvfYalEolDh8+jK1btw7rdbGPnojov9RqNWJjY1FUVITbbrsNRUVFWLZsGf7v//4P586dg16vR1VVFaZNm4ZrrrkGTzzxhGnfpUuX4qOPPsLbb7+NyZMnQ61WQ6lUwtPT0+zb+S+99BJuvfVWrFu3zrRu+/btCA0Nxffff4/rr78eABAVFYX169fb5HWxRU9EdJlp06ahqKgIgiDg0KFDuO+++3DDDTfg888/R3FxMUJCQhAVFYWenh6sXbsWMTEx8PPzg5eXFz766CPU1tZe9fjl5eX47LPP4OXlZVomTJgAAGY3FI+Li7PZa2KLnojoMomJidi+fTvKy8vh5uaGCRMmIDExEUVFRTh79iymTZsGAHj++eexadMm5OfnIyYmBqNHj0Z2dvagH5yeO3cO99xzD/7617/2ey44ONj0794bKtkCg56I6DK9/fQbN240hXpiYiKee+45nD17FsuXLwcAHD58GPfeey/mz58P4NL06d9//z2io6NNx1IqlaYPdntNnDgR77zzDsLDwzFqlGMimF03RESX8fX1xc0334w33njDNOXK1KlT8dVXX+H77783hX9UVBQKCgpw5MgRfPfdd1iyZEm/e1SHh4fj6NGjqKmpQWtrK4xGIzIzM/Hzzz/jwQcfxJdffonTp0/jo48+woIFC/r9UrAVBj0ROYS//6UvMDmSu/ul81pr2rRp6OnpMQW9n58foqOjodVqMX78eADAqlWrMHHiRCQnJyMxMRFarRYpKSlmx3niiSfg6uqK6OhoBAQEoLa2FiEhITh8+DB6enowa9YsxMTEIDs7GxqNBi4u9olkyd4z1l54z1iigQ375uCcAsFmrLlnLPvoichhwsLkG7zOjF03REQyx6AnIpI5Bj0Rkcwx6InIbjjWw36subYMeiKyOVdXVwDDn16XBnbhwgUAgJub26DbctQNEdncqFGj4OnpiZaWFri5udltfPhIJAgCLly4gObmZmg0GtMv1ath0BORzSkUCgQHB6O6uhpnzpwRuxxZ0mg0ZrNiXg2DnojsQqlUIioqit03duDm5mZRS74Xg56I7MbFxWXQb22S/bHjjIhI5hj0REQyx6AnIpI5Bj0Rkcwx6ImIZI5BT0Qkcwx6IiKZk1TQHzx4EPfccw9CQkKgUCiwb98+s+cFQcDTTz+N4OBgeHh4ICkpCT/88IM4xZJVFIqhLUQ0OEkF/fnz53HLLbdg8+bNV3x+/fr1eOGFF7B161YcPXoUo0ePRnJyMjo6OhxcKQ3GVoHN4CcanKS+GTt79mzMnj37is8JgoD8/HysWrUK9957LwDgn//8J4KCgrBv3z488MADjiyV+nBUCPc9D2fJJZJYi/5qqqurodPpkJSUZFqnVqsxZcoUlJSUDLhfZ2cnDAaD2UK2I3ZLW+zzEzkD2QS9TqcDAAQFBZmtDwoKMj13JXl5eVCr1aYlNDTUrnWOFM4WsM5WD5EjySbohyo3Nxd6vd601NXViV2SpDl7oDp7fUT2IKk++qvpnZe5qakJwcHBpvVNTU2IjY0dcD+VSgWVSmXv8mRPauHZWy/78GkkkE2LPiIiAlqtFoWFhaZ1BoMBR48eRXx8vIiVyZvUW8hSr5/IEpJq0Z87dw5VVVWmx9XV1SgrK4Ofnx/CwsKQnZ2Nv/zlL4iKikJERAT+/Oc/IyQkBCkpKeIVLWM2D8g1Vh5wje2a4woFW/ckX5IK+uPHj2P69Ommxzk5OQCAtLQ07Ny5E3/6059w/vx5LF68GG1tbbjjjjtw4MAB3vjADmwS8tYG+2D7DzP4GfYkVwpB4I/25QwGA9RqNfR6PXx8fMQux+kMO+CHG+4Wn2d4P9Z8V1wZ3x/SJKkWPYlrWCHvqIDve74hBj5b9yQnDHqyyJBD3tEBP9D5hxD4DHuSCwY9DWpIIS92wPc1xMBn2JMcMOjpqqwOeWcL+L6GEPgMe5I62YyjJ9uTXchfzspaOdaepIxBT7YhpZDvJcWaiYaAQU9XZFULVsqBaUXtbNWTVDHoqZ8RE/K9GPYkcwx6MjPiQr4Xw55kjEFPQyOnkO8lx9dEBAY9XcbilqqcA9HC18ZWPUkJg56sI+eQ7zUSXiONKBZ9Yap3lkhrrFq1Cn5+flbvR+KwqIU6kgJwjWLQL1Xxi1QkFRYFfX5+PuLj46FUKi066Oeff46srCwGPRGRE7B4CoR3330XgYGBFm3r7e095ILI8diaHwBb9SQTFvXR79ixA2q12uKDbtu2DUFBQUMuioiIbIc3HuljpN1Yga15C1gwAdpIeReNtPeHXAxr9spz587BaDSareN/PhGRc7F6eGV1dTXuvvtujB49Gmq1Gr6+vvD19YVGo4Gvr689aiQ7YWveQhZcA46rJ2dmdYt+/vz5EAQB27dvR1BQEBT8CScicmpWB315eTlKS0sxfvx4e9RDzoSt+f+xYAQOkbOyuutm0qRJqKurs0ctRERkB1a36P/xj3/gscceQ319PW666Sa4ubmZPX/zzTfbrDiyH/a42R7H1JOzsjroW1pacPr0aSxYsMC0TqFQQBAEKBQK9PT02LRAEgm7bfpj9w1JlNVB/8gjj+DWW2/FW2+9xQ9jiYgkwOqgP3PmDN577z1ERkbaox4iIrIxqz+MnTFjBsrLy+1RCzkI/wizH15bckZWt+jvueceLFu2DCdPnkRMTEy/D2N/85vf2Kw4Egn75wfGfnqSIKvnunFxGfiPADl8GDsS5vIYtNXJoL+6QYJeziNvRsL7Q46s7roxGo0DLs4S8ps3b0Z4eDjc3d0xZcoUHDt2TOySiIhEI7tbCe7evRs5OTlYvXo1vvrqK9xyyy1ITk5Gc3Oz2KUREYnC6qD/wx/+gBdeeKHf+pdeegnZ2dm2qGlY/v73v2PRokVYsGABoqOjsXXrVnh6emL79u1il0ZEJAqrg/6dd97B7bff3m99QkIC9u7da5OihqqrqwulpaVISkoyrXNxcUFSUhJKSkquuE9nZycMBoPZQkQkJ1YH/U8//XTFu035+PigtbXVJkUNVWtrK3p6evrd3SooKAg6ne6K++Tl5UGtVpuW0NBQR5RKROQwVgd9ZGQkDhw40G/9hx9+iHHjxtmkKEfKzc2FXq83LZywjYjkxupx9Dk5OcjKykJLSwtmzJgBACgsLMTf/vY35Ofn27o+q/j7+8PV1RVNTU1m65uamqDVaq+4j0qlgkqlckR5RESiGNJcN52dnXj22Wexdu1aAEB4eDi2bNmChx9+2OYFWkOpVCIuLg6FhYVISUkBcGk4aGFhIbKyskStjYhILEO6Z2xGRgYyMjLQ0tICDw8PeHl52bquIcvJyUFaWhpuu+02TJ48Gfn5+Th//rzZbJtERCPJsG4OHhAQYKs6bOb+++9HS0sLnn76aeh0OsTGxuLAgQP9PqAlIhopLPowduLEiTh79qzFB73jjjtQX18/5KKGKysrC2fOnEFnZyeOHj2KKVOmiFaLJHEul4Hx2pAEWdSiLysrQ3l5Ofz8/Cw6aFlZGTo7O4dVGNmPIHCWRXuR8zw3JF0Wd93MnDkTls5/xpuREBE5D4uCvrq62uoDjx071up9iIjI9iwK+muvvdbedZCzWSNwuuK+2D9PEiW72SvJMuxLtj1eU3JWDHoiIplj0NPA2FXxP7wWJGEMeiIimbM66NPS0nDw4EF71EIOZlGfMluyFl0D9s+TM7M66PV6PZKSkhAVFYV169aJ+g1YIiIanNVBv2/fPtTX1yMjIwO7d+9GeHg4Zs+ejb1796K7u9seNZIdsVU/CLbmSQaG1EcfEBCAnJwclJeX4+jRo4iMjERqaipCQkKwbNky/PDDD7auk4iIhmhYH8Y2NjaioKAABQUFcHV1xa9//WucPHkS0dHR2Lhxo61qJDtjq34AbM2TTFgd9N3d3XjnnXcwZ84cXHvttdizZw+ys7PR0NCA1157DZ988gnefvttPPPMM/aol4iIrGT1fPTBwcEwGo148MEHcezYMcTGxvbbZvr06dBoNDYojxzFohktR9K0CGzNk4xYHfQbN27EvHnz4O7uPuA2Go1mSBOhkQSMhLAfid1UJGtWd92kpqZeNeRJuixuoco5CC18bWzNk5Twm7E0NHIMezm+JiIw6KkPq1qqcgpGK14LW/MkNQx66mfEhT1DnmSOQU9XNGLCniFPIwCDnmxDimEvxZqJhoBBTwOyugUrpeC0sla25knKrB5HTyOLRV+kulxvgDrrWPsh/DJiyJPUMehpUFaHPeB8gT/EvzYY8iQHDHqyyJDCHhA/8IfRncSQJ7lg0JPFhhz2gOMDf5ifFzDkSU4Y9GSV3gAcduADtg99G3wYzIAnOWLQ05AMq3Xfq28wWxv8Nh7lw5AnuZJM0D/77LN4//33UVZWBqVSiba2tn7b1NbWIiMjA5999hm8vLyQlpaGvLw8jBolmZcpKTYJ+8uJODyTIU9yJpkE7Orqwrx58xAfH49XX3213/M9PT24++67odVqceTIETQ2NuLhhx+Gm5sb1q1bJ0LFI8Owu3JExoCnkUAhCNL6Ud+5cyeys7P7teg//PBDzJkzBw0NDQgKCgIAbN26FU8++SRaWlqgVCotOr7BYIBarYZer4ePj4+ty5c9qQS+tH7qnQffH9Ikm2/GlpSUICYmxhTyAJCcnAyDwYBvvvlmwP06OzthMBjMFho6QXDuEHX2+ojsQTZBr9PpzEIegOmxTqcbcL+8vDyo1WrTEhoaatc6RwpnC1Rnq4fIkUQN+hUrVkChUFx1OXXqlF1ryM3NhV6vNy11dXV2Pd9II3bAin1+Imcg6oexy5cvR3p6+lW3GTdunEXH0mq1OHbsmNm6pqYm03MDUalUUKlUFp2Dhq5v2NqrL5+hTtSfqEEfEBCAgIAAmxwrPj4ezz77LJqbmxEYGAgAKCgogI+PD6Kjo21yDrIdWwU/g51ocJIZXllbW4uff/4ZtbW16OnpQVlZGQAgMjISXl5emDVrFqKjo5Gamor169dDp9Nh1apVyMzMZItdAhjYRPYjmeGV6enpeO211/qt/+yzz5CYmAgAOHPmDDIyMlBUVITRo0cjLS0Nzz33nFVfmOLwMaKB8f0hTZIJekfhDzLRwPj+kCbZDK8kIqIrY9ATEckcg56ISOYY9EREMsegJyKSOQY9EZHMMeiJiGSOQU9EJHMMeiIimWPQExHJHIOeiEjmGPRERDLHoCcikjkGPRGRzDHoiYhkjkFPRCRzDHoiIplj0BMRyRyDnohI5hj0REQyx6AnIpI5Bj0Rkcwx6ImIZI5BT0Qkcwx6IiKZY9ATEckcg56ISOYY9EREMsegJyKSOUkEfU1NDRYuXIiIiAh4eHjguuuuw+rVq9HV1WW23ddff40777wT7u7uCA0Nxfr160WqmIjIeYwSuwBLnDp1CkajEdu2bUNkZCQqKiqwaNEinD9/Hhs2bAAAGAwGzJo1C0lJSdi6dStOnjyJRx55BBqNBosXLxb5FRARiUchCIIgdhFD8fzzz2PLli34z3/+AwDYsmULVq5cCZ1OB6VSCQBYsWIF9u3bh1OnTll8XIPBALVaDb1eDx8fH7vUTiRVfH9IkyS6bq5Er9fDz8/P9LikpARTp041hTwAJCcno7KyEmfPnh3wOJ2dnTAYDGYLEZGcSDLoq6qq8OKLL2LJkiWmdTqdDkFBQWbb9T7W6XQDHisvLw9qtdq0hIaG2qdoIiKRiBr0K1asgEKhuOrSt9ulvr4ed911F+bNm4dFixYNu4bc3Fzo9XrTUldXN+xjEhE5E1E/jF2+fDnS09Ovus24ceNM/25oaMD06dORkJCAV155xWw7rVaLpqYms3W9j7Va7YDHV6lUUKlUVlZORCQdogZ9QEAAAgICLNq2vr4e06dPR1xcHHbs2AEXF/M/RuLj47Fy5Up0d3fDzc0NAFBQUIDx48fD19fX5rUTEUmFJPro6+vrkZiYiLCwMGzYsAEtLS3Q6XRmfe8PPfQQlEolFi5ciG+++Qa7d+/Gpk2bkJOTI2LlRETik8Q4+oKCAlRVVaGqqgpjx441e653dKharcbHH3+MzMxMxMXFwd/fH08//TTH0BPRiCfZcfT2wnHCRAPj+0OaJNF1Q0REQ8egJyKSOQY9EZHMMeiJiGSOQU9EJHMMeiIimWPQExHJHIOeiEjmGPRERDLHoCcikjkGPRGRzDHoiYhkThKzVzpS7xxvvHcsUX+97wvOhSgtDPo+2tvbAYD3jiW6ivb2dqjVarHLIAtxmuI+jEYjGhoa4O3tDYVCMezjGQwGhIaGoq6ujtO6DgGv3/DY+voJgoD29naEhIT0u8sbOS+26PtwcXHpd3MTW/Dx8WFQDQOv3/DY8vqxJS89/JVMRCRzDHoiIplj0NuZSqXC6tWroVKpxC5Fknj9hofXjwB+GEtEJHts0RMRyRyDnohI5hj0REQyx6AnIpI5Br0d1NTUYOHChYiIiICHhweuu+46rF69Gl1dXWbbff3117jzzjvh7u6O0NBQrF+/XqSKndPmzZsRHh4Od3d3TJkyBceOHRO7JKeUl5eHSZMmwdvbG4GBgUhJSUFlZaXZNh0dHcjMzMSYMWPg5eWFuXPnoqmpSaSKydEY9HZw6tQpGI1GbNu2Dd988w02btyIrVu34qmnnjJtYzAYMGvWLFx77bUoLS3F888/jzVr1uCVV14RsXLnsXv3buTk5GD16tX46quvcMsttyA5ORnNzc1il+Z0iouLkZmZiS+++AIFBQXo7u7GrFmzcP78edM2y5Ytw7///W/s2bMHxcXFaGhowH333Sdi1eRQAjnE+vXrhYiICNPjl19+WfD19RU6OztN65588klh/PjxYpTndCZPnixkZmaaHvf09AghISFCXl6eiFVJQ3NzswBAKC4uFgRBENra2gQ3Nzdhz549pm2+++47AYBQUlIiVpnkQGzRO4her4efn5/pcUlJCaZOnQqlUmlal5ycjMrKSpw9e1aMEp1GV1cXSktLkZSUZFrn4uKCpKQklJSUiFiZNOj1egAw/byVlpaiu7vb7HpOmDABYWFhvJ4jBIPeAaqqqvDiiy9iyZIlpnU6nQ5BQUFm2/U+1ul0Dq3P2bS2tqKnp+eK12ekX5vBGI1GZGdn4/bbb8dNN90E4NLPk1KphEajMduW13PkYNBbYcWKFVAoFFddTp06ZbZPfX097rrrLsybNw+LFi0SqXIaKTIzM1FRUYFdu3aJXQo5EU5TbIXly5cjPT39qtuMGzfO9O+GhgZMnz4dCQkJ/T5k1Wq1/UY99D7WarW2KVii/P394erqesXrM9KvzdVkZWVh//79OHjwoNlU21qtFl1dXWhrazNr1fN6jhwMeisEBAQgICDAom3r6+sxffp0xMXFYceOHf1u0hAfH4+VK1eiu7sbbm5uAICCggKMHz8evr6+Nq9dSpRKJeLi4lBYWIiUlBQAl7okCgsLkZWVJW5xTkgQBCxduhTvvvsuioqKEBERYfZ8XFwc3NzcUFhYiLlz5wIAKisrUVtbi/j4eDFKJkcT+9NgOfrxxx+FyMhIYebMmcKPP/4oNDY2mpZebW1tQlBQkJCamipUVFQIu3btEjw9PYVt27aJWLnz2LVrl6BSqYSdO3cK3377rbB48WJBo9EIOp1O7NKcTkZGhqBWq4WioiKzn7ULFy6YtnnssceEsLAw4dNPPxWOHz8uxMfHC/Hx8SJWTY7EoLeDHTt2CACuuFyuvLxcuOOOOwSVSiVcc801wnPPPSdSxc7pxRdfFMLCwgSlUilMnjxZ+OKLL8QuySkN9LO2Y8cO0za//PKL8Pjjjwu+vr6Cp6en8Nvf/tas4UHyxmmKiYhkjqNuiIhkjkFPRCRzDHoiIplj0BMRyRyDnohI5hj0REQyx6AnIpI5Bj2JpqamxjQZXGxsrF3PtXPnTtO5srOz7XouImfDoCfRffLJJygsLLTrOe6//340NjZybhcakTipGYluzJgxGDNmjF3P4eHhAQ8PD7MbvRCNFGzRk020tLRAq9Vi3bp1pnVHjhyBUqkcUmt9+/btuPHGG6FSqRAcHGw2a6VCocC2bdswZ84ceHp64oYbbkBJSQmqqqqQmJiI0aNHIyEhAadPn7bJayOSOgY92URAQAC2b9+ONWvW4Pjx42hvb0dqaiqysrIwc+ZMq461ZcsWZGZmYvHixTh58iTee+89REZGmm2zdu1aPPzwwygrK8OECRPw0EMPYcmSJcjNzcXx48chCAKnNCbqJfKkaiQzjz/+uHD99dcLDz30kBATEyN0dHQMuG11dbUAQDhx4oTZ+pCQEGHlypUD7gdAWLVqlelxSUmJAEB49dVXTeveeustwd3dvd++06ZNE/74xz9a/oKIZIAterKpDRs24OLFi9izZw/eeOMNqFQqq/Zvbm5GQ0PDoH8F3HzzzaZ/995bNiYmxmxdR0cHDAaDVecnkiMGPdnU6dOn0dDQAKPRiJqaGqv39/DwsGi73rtyAZf67AdaZzQara6BSG4Y9GQzXV1dmD9/Pu6//36sXbsWjz76KJqbm606hre3N8LDw+0+3JJoJOHwSrKZlStXQq/X44UXXoCXlxc++OADPPLII9i/f79Vx1mzZg0ee+wxBAYGYvbs2Whvb8fhw4exdOlSO1VOJG9s0ZNNFBUVIT8/H6+//jp8fHzg4uKC119/HYcOHcKWLVusOlZaWhry8/Px8ssv48Ybb8ScOXPwww8/2KlyIvnjrQRJNDU1NYiIiMCJEyfsPgVCr8TERMTGxiI/P98h5yNyBmzRk+gSEhKQkJBg13O88cYb8PLywqFDh+x6HiJnxBY9iebixYumkTkqlQqhoaF2O1d7ezuampoAABqNBv7+/nY7F5GzYdATEckcu26IiGSOQU9EJHMMeiIimWPQExHJHIOeiEjmGPRERDLHoCcikjkGPRGRzDHoiYhk7v8BlgdCuPhTr2cAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 258.065x259.74 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model.plot(color_by='material', colors=material_colors, legend=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{10000: Cell\n",
+       " \tID             =\t10000\n",
+       " \tName           =\t\n",
+       " \tFill           =\t5\n",
+       " \tRegion         =\t(10000 -10001 10002 -10003 10004 -10005)\n",
+       " \tRotation       =\tNone\n",
+       " \tTranslation    =\tNone\n",
+       " \tVolume         =\tNone}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.geometry.get_all_cells()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly, requesting all material cells returns an empty result, yet we know that material-filled cells must exist in this model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "model.geometry.get_all_material_cells()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dag_univ.get_all_cells()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By initializing the model we can populate additional information on this universe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                %%%%%%%%%%%%%%%\n",
+      "                           %%%%%%%%%%%%%%%%%%%%%%%%\n",
+      "                        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n",
+      "                      %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n",
+      "                    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n",
+      "                   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n",
+      "                                    %%%%%%%%%%%%%%%%%%%%%%%%\n",
+      "                                     %%%%%%%%%%%%%%%%%%%%%%%%\n",
+      "                 ###############      %%%%%%%%%%%%%%%%%%%%%%%%\n",
+      "                ##################     %%%%%%%%%%%%%%%%%%%%%%%\n",
+      "                ###################     %%%%%%%%%%%%%%%%%%%%%%%\n",
+      "                ####################     %%%%%%%%%%%%%%%%%%%%%%\n",
+      "                #####################     %%%%%%%%%%%%%%%%%%%%%\n",
+      "                ######################     %%%%%%%%%%%%%%%%%%%%\n",
+      "                #######################     %%%%%%%%%%%%%%%%%%\n",
+      "                 #######################     %%%%%%%%%%%%%%%%%\n",
+      "                 ######################     %%%%%%%%%%%%%%%%%\n",
+      "                  ####################     %%%%%%%%%%%%%%%%%\n",
+      "                    #################     %%%%%%%%%%%%%%%%%\n",
+      "                     ###############     %%%%%%%%%%%%%%%%\n",
+      "                       ############     %%%%%%%%%%%%%%%\n",
+      "                          ########     %%%%%%%%%%%%%%\n",
+      "                                      %%%%%%%%%%%\n",
+      "\n",
+      "                 | The OpenMC Monte Carlo Code\n",
+      "       Copyright | 2011-2025 MIT, UChicago Argonne LLC, and contributors\n",
+      "         License | https://docs.openmc.org/en/latest/license.html\n",
+      "         Version | 0.15.1\n",
+      "     Commit Hash | 906548db20d4ce3c322e7317992c73b51daeb11d\n",
+      "       Date/Time | 2025-03-17 23:10:09\n",
+      "  OpenMP Threads | 16\n",
+      "\n",
+      " Reading settings XML file...\n",
+      " Reading cross sections XML file...\n",
+      " Reading materials XML file...\n",
+      " Reading geometry XML file...\n",
+      "Loading file /home/pshriwise/repos/openmc-notebooks/fuel_pin.h5m\n",
+      "Initializing the GeomQueryTool...\n",
+      "Using faceting tolerance: 0.0001\n",
+      "Building acceleration data structures...\n",
+      " Reading U235 from\n",
+      " /home/pshriwise/data/xs/openmc/endfb-vii.1-hdf5/neutron/U235.h5\n",
+      " Reading H1 from /home/pshriwise/data/xs/openmc/endfb-vii.1-hdf5/neutron/H1.h5\n",
+      " Reading O16 from /home/pshriwise/data/xs/openmc/endfb-vii.1-hdf5/neutron/O16.h5\n",
+      " Reading c_H_in_H2O from\n",
+      " /home/pshriwise/data/xs/openmc/endfb-vii.1-hdf5/neutron/c_H_in_H2O.h5\n",
+      " Minimum neutron data temperature: 0 K\n",
+      " Maximum neutron data temperature: 1.7976931348623157e+308 K\n",
+      " Preparing distributed cell instances...\n",
+      " Reading plot XML file...\n",
+      " Writing summary.h5 file...\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.init_lib()\n",
+    "model.sync_dagmc_universes()\n",
+    "model.finalize_lib()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{np.int32(1): Cell\n",
+       " \tID             =\t1\n",
+       " \tName           =\t\n",
+       " \tFill           =\tMaterial 40\n",
+       " \tRegion         =\tNone\n",
+       " \tRotation       =\tNone\n",
+       " \tTemperature    =\tNone\n",
+       " \tTranslation    =\tNone\n",
+       " \tVolume         =\tNone,\n",
+       " np.int32(2): Cell\n",
+       " \tID             =\t2\n",
+       " \tName           =\t\n",
+       " \tFill           =\tMaterial 40\n",
+       " \tRegion         =\tNone\n",
+       " \tRotation       =\tNone\n",
+       " \tTemperature    =\tNone\n",
+       " \tTranslation    =\tNone\n",
+       " \tVolume         =\tNone,\n",
+       " np.int32(3): Cell\n",
+       " \tID             =\t3\n",
+       " \tName           =\t\n",
+       " \tFill           =\tMaterial 41\n",
+       " \tRegion         =\tNone\n",
+       " \tRotation       =\tNone\n",
+       " \tTemperature    =\tNone\n",
+       " \tTranslation    =\tNone\n",
+       " \tVolume         =\tNone}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.geometry.get_all_material_cells()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{np.int32(1): Cell\n",
+       " \tID             =\t1\n",
+       " \tName           =\t\n",
+       " \tFill           =\tMaterial 40\n",
+       " \tRegion         =\tNone\n",
+       " \tRotation       =\tNone\n",
+       " \tTemperature    =\tNone\n",
+       " \tTranslation    =\tNone\n",
+       " \tVolume         =\tNone,\n",
+       " np.int32(2): Cell\n",
+       " \tID             =\t2\n",
+       " \tName           =\t\n",
+       " \tFill           =\tMaterial 40\n",
+       " \tRegion         =\tNone\n",
+       " \tRotation       =\tNone\n",
+       " \tTemperature    =\tNone\n",
+       " \tTranslation    =\tNone\n",
+       " \tVolume         =\tNone,\n",
+       " np.int32(3): Cell\n",
+       " \tID             =\t3\n",
+       " \tName           =\t\n",
+       " \tFill           =\tMaterial 41\n",
+       " \tRegion         =\tNone\n",
+       " \tRotation       =\tNone\n",
+       " \tTemperature    =\tNone\n",
+       " \tTranslation    =\tNone\n",
+       " \tVolume         =\tNone,\n",
+       " np.int32(6): Cell\n",
+       " \tID             =\t6\n",
+       " \tName           =\t\n",
+       " \tFill           =\tNone\n",
+       " \tRegion         =\tNone\n",
+       " \tRotation       =\tNone\n",
+       " \tTranslation    =\tNone\n",
+       " \tVolume         =\tNone,\n",
+       " np.int32(7): Cell\n",
+       " \tID             =\t7\n",
+       " \tName           =\t\n",
+       " \tFill           =\tNone\n",
+       " \tRegion         =\tNone\n",
+       " \tRotation       =\tNone\n",
+       " \tTranslation    =\tNone\n",
+       " \tVolume         =\tNone}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dag_univ.get_all_cells()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to being able to view this as-initialized information. The synchonized `DAGMCUniverse` now provides us with some powerful capabilities, like the ability to modify material assignments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: xlabel='x [cm]', ylabel='y [cm]'>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAEHCAYAAACgHI2PAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAIaBJREFUeJzt3X1UVHX+B/D3gMwAAjMgDwMJgUEaRZGkLlSKypHcbGNz3R6OBGZqBO4idjZJN/3lJq25K1amdja17VSadnJbK4so0JQ0SUgqKVwQAoaHkhnUeJC5vz9cZh0QmYGZuXMv79c59xznzn34zJV58+U73/lehSAIAoiISLZcxC6AiIjsi0FPRCRzDHoiIplj0BMRyRyDnohI5hj0REQyx6AnIpI5Bj0RkcyNErsAZ2M0GtHQ0ABvb28oFAqxyyFyKoIgoL29HSEhIXBxGbydaDQa0dXV5YDKRhY3Nze4urpavD2Dvo+GhgaEhoaKXQaRU6urq8PYsWOvuk1XVxeqq6thNBodVNXIotFooNVqLWqQMuj78Pb2BnDpB9nHx0fkaoici8FgQGhoqOl9MhBBENDY2AhXV1eEhoZa1PonywiCgAsXLqC5uRkAEBwcPOg+DPo+en87+vj4MOiJBjBYK/LixYu4cOECQkJC4Onp6aCqRg4PDw8AQHNzMwIDAwftxuGvWSKyuZ6eHgCAUqkUuRL56v0F2t3dPei2DHoishsOaLAfa64tg56ISObYR09EDlOrr0XrhVaHnc/f0x9h6jCLtxcEAUuWLMHevXtx9uxZnDhxArGxscOqYc2aNdi3bx/KysqGdZzhYNATkUPU6msx/qXx6LjY4bBzuo9yR2VWpcVhf+DAAezcuRNFRUUYN24c/P397VyhYzDoicghWi+0OjTkAaDjYgdaL7RaHPSnT59GcHAwEhIS7FyZY7GPnogIQHp6OpYuXYra2looFAqEh4cjPDwc+fn5ZtvFxsZizZo1psdtbW149NFHERAQAB8fH8yYMQPl5eWOLX4QDHoiIgCbNm3CM888g7Fjx6KxsRFffvmlRfvNmzcPzc3N+PDDD1FaWoqJEydi5syZ+Pnnn+1cseUY9EREANRqNby9veHq6gqtVouAgIBB9/n8889x7Ngx7NmzB7fddhuioqKwYcMGaDQa7N271wFVW4Z99EREQ1ReXo5z585hzJgxZut/+eUXnD59WqSq+mPQExENwMXFBYIgmK27/Juo586dQ3BwMIqKivrtq9Fo7Fyd5Rj0REQDCAgIQGNjo+mxwWBAdXW16fHEiROh0+kwatQohIeHi1ChZdhHT0Q0gBkzZuD111/HoUOHcPLkSaSlpZlNIJaUlIT4+HikpKTg448/Rk1NDY4cOYKVK1fi+PHjIlZuTjJBn5eXh0mTJsHb2xuBgYFISUlBZWWl2TYdHR3IzMzEmDFj4OXlhblz56KpqUmkionocv6e/nAf5e7Qc7qPcoe/59C/9JSbm4tp06Zhzpw5uPvuu5GSkoLrrrvO9LxCocAHH3yAqVOnYsGCBbj++uvxwAMP4MyZMwgKCrLFS7AJhdC3A8pJ3XXXXXjggQcwadIkXLx4EU899RQqKirw7bffYvTo0QCAjIwMvP/++9i5cyfUajWysrLg4uKCw4cPW3weg8EAtVoNvV7PaYqJ+rD0/dHR0YHq6mpERETA3f1/4e7sUyBIyUDX+EokE/R9tbS0IDAwEMXFxZg6dSr0ej0CAgLw5ptv4ne/+x0A4NSpU7jhhhtQUlKCX/3qVxYdl0FPNLDhBj3ZjjXXWDJdN33p9XoAgJ+fHwCgtLQU3d3dSEpKMm0zYcIEhIWFoaSkZMDjdHZ2wmAwmC1ERHIiyaA3Go3Izs7G7bffjptuugkAoNPpoFQq+w1pCgoKgk6nG/BYeXl5UKvVpoX3iyUiuZFk0GdmZqKiogK7du0a9rFyc3Oh1+tNS11dnQ0qJCJyHpIbR5+VlYX9+/fj4MGDZneh12q16OrqQltbm1mrvqmpCVqtdsDjqVQqqFQqe5ZMRCQqybToBUFAVlYW3n33XXz66aeIiIgwez4uLg5ubm4oLCw0rausrERtbS3i4+MdXS4RkdOQTIs+MzMTb775Jv71r3/B29vb1O+uVqvh4eEBtVqNhQsXIicnB35+fvDx8cHSpUsRHx9v8YgbIiI5kkzQb9myBQCQmJhotn7Hjh1IT08HAGzcuBEuLi6YO3cuOjs7kZycjJdfftnBlRIRORfJBL0lw/3d3d2xefNmbN682QEVERFJg2SCnoikr7YWaHXcF2Ph7w+EyfOLsVZh0BORQ9TWAuPHAx0OvG2suztQWSle2CcmJiI2Nrbf7QgdTTKjbohI2lpbHRvywKXzOfIvCHvp6uoa1v4MeiKi/9q/fz80Gg16enoAAGVlZVAoFFixYoVpm0cffRTz58/HTz/9hAcffBDXXHMNPD09ERMTg7feesu0XXp6OoqLi7Fp0yYoFAooFArU1NQAACoqKjB79mx4eXkhKCgIqampaL3sN1JiYiKysrKQnZ0Nf39/JCcnD+t1MeiJiP7rzjvvRHt7O06cOAEAKC4uhr+/v9kdpIqLi5GYmIiOjg7ExcXh/fffR0VFBRYvXozU1FQcO3YMwKWbjcfHx2PRokVobGxEY2MjQkND0dbWhhkzZuDWW2/F8ePHceDAATQ1NeH3v/+9WS2vvfYalEolDh8+jK1btw7rdbGPnojov9RqNWJjY1FUVITbbrsNRUVFWLZsGf7v//4P586dg16vR1VVFaZNm4ZrrrkGTzzxhGnfpUuX4qOPPsLbb7+NyZMnQ61WQ6lUwtPT0+zb+S+99BJuvfVWrFu3zrRu+/btCA0Nxffff4/rr78eABAVFYX169fb5HWxRU9EdJlp06ahqKgIgiDg0KFDuO+++3DDDTfg888/R3FxMUJCQhAVFYWenh6sXbsWMTEx8PPzg5eXFz766CPU1tZe9fjl5eX47LPP4OXlZVomTJgAAGY3FI+Li7PZa2KLnojoMomJidi+fTvKy8vh5uaGCRMmIDExEUVFRTh79iymTZsGAHj++eexadMm5OfnIyYmBqNHj0Z2dvagH5yeO3cO99xzD/7617/2ey44ONj0794bKtkCg56I6DK9/fQbN240hXpiYiKee+45nD17FsuXLwcAHD58GPfeey/mz58P4NL06d9//z2io6NNx1IqlaYPdntNnDgR77zzDsLDwzFqlGMimF03RESX8fX1xc0334w33njDNOXK1KlT8dVXX+H77783hX9UVBQKCgpw5MgRfPfdd1iyZEm/e1SHh4fj6NGjqKmpQWtrK4xGIzIzM/Hzzz/jwQcfxJdffonTp0/jo48+woIFC/r9UrAVBj0ROYS//6UvMDmSu/ul81pr2rRp6OnpMQW9n58foqOjodVqMX78eADAqlWrMHHiRCQnJyMxMRFarRYpKSlmx3niiSfg6uqK6OhoBAQEoLa2FiEhITh8+DB6enowa9YsxMTEIDs7GxqNBi4u9olkyd4z1l54z1iigQ375uCcAsFmrLlnLPvoichhwsLkG7zOjF03REQyx6AnIpI5Bj0Rkcwx6InIbjjWw36subYMeiKyOVdXVwDDn16XBnbhwgUAgJub26DbctQNEdncqFGj4OnpiZaWFri5udltfPhIJAgCLly4gObmZmg0GtMv1ath0BORzSkUCgQHB6O6uhpnzpwRuxxZ0mg0ZrNiXg2DnojsQqlUIioqit03duDm5mZRS74Xg56I7MbFxWXQb22S/bHjjIhI5hj0REQyx6AnIpI5Bj0Rkcwx6ImIZI5BT0Qkcwx6IiKZk1TQHzx4EPfccw9CQkKgUCiwb98+s+cFQcDTTz+N4OBgeHh4ICkpCT/88IM4xZJVFIqhLUQ0OEkF/fnz53HLLbdg8+bNV3x+/fr1eOGFF7B161YcPXoUo0ePRnJyMjo6OhxcKQ3GVoHN4CcanKS+GTt79mzMnj37is8JgoD8/HysWrUK9957LwDgn//8J4KCgrBv3z488MADjiyV+nBUCPc9D2fJJZJYi/5qqqurodPpkJSUZFqnVqsxZcoUlJSUDLhfZ2cnDAaD2UK2I3ZLW+zzEzkD2QS9TqcDAAQFBZmtDwoKMj13JXl5eVCr1aYlNDTUrnWOFM4WsM5WD5EjySbohyo3Nxd6vd601NXViV2SpDl7oDp7fUT2IKk++qvpnZe5qakJwcHBpvVNTU2IjY0dcD+VSgWVSmXv8mRPauHZWy/78GkkkE2LPiIiAlqtFoWFhaZ1BoMBR48eRXx8vIiVyZvUW8hSr5/IEpJq0Z87dw5VVVWmx9XV1SgrK4Ofnx/CwsKQnZ2Nv/zlL4iKikJERAT+/Oc/IyQkBCkpKeIVLWM2D8g1Vh5wje2a4woFW/ckX5IK+uPHj2P69Ommxzk5OQCAtLQ07Ny5E3/6059w/vx5LF68GG1tbbjjjjtw4MAB3vjADmwS8tYG+2D7DzP4GfYkVwpB4I/25QwGA9RqNfR6PXx8fMQux+kMO+CHG+4Wn2d4P9Z8V1wZ3x/SJKkWPYlrWCHvqIDve74hBj5b9yQnDHqyyJBD3tEBP9D5hxD4DHuSCwY9DWpIIS92wPc1xMBn2JMcMOjpqqwOeWcL+L6GEPgMe5I62YyjJ9uTXchfzspaOdaepIxBT7YhpZDvJcWaiYaAQU9XZFULVsqBaUXtbNWTVDHoqZ8RE/K9GPYkcwx6MjPiQr4Xw55kjEFPQyOnkO8lx9dEBAY9XcbilqqcA9HC18ZWPUkJg56sI+eQ7zUSXiONKBZ9Yap3lkhrrFq1Cn5+flbvR+KwqIU6kgJwjWLQL1Xxi1QkFRYFfX5+PuLj46FUKi066Oeff46srCwGPRGRE7B4CoR3330XgYGBFm3r7e095ILI8diaHwBb9SQTFvXR79ixA2q12uKDbtu2DUFBQUMuioiIbIc3HuljpN1Yga15C1gwAdpIeReNtPeHXAxr9spz587BaDSareN/PhGRc7F6eGV1dTXuvvtujB49Gmq1Gr6+vvD19YVGo4Gvr689aiQ7YWveQhZcA46rJ2dmdYt+/vz5EAQB27dvR1BQEBT8CScicmpWB315eTlKS0sxfvx4e9RDzoSt+f+xYAQOkbOyuutm0qRJqKurs0ctRERkB1a36P/xj3/gscceQ319PW666Sa4ubmZPX/zzTfbrDiyH/a42R7H1JOzsjroW1pacPr0aSxYsMC0TqFQQBAEKBQK9PT02LRAEgm7bfpj9w1JlNVB/8gjj+DWW2/FW2+9xQ9jiYgkwOqgP3PmDN577z1ERkbaox4iIrIxqz+MnTFjBsrLy+1RCzkI/wizH15bckZWt+jvueceLFu2DCdPnkRMTEy/D2N/85vf2Kw4Egn75wfGfnqSIKvnunFxGfiPADl8GDsS5vIYtNXJoL+6QYJeziNvRsL7Q46s7roxGo0DLs4S8ps3b0Z4eDjc3d0xZcoUHDt2TOySiIhEI7tbCe7evRs5OTlYvXo1vvrqK9xyyy1ITk5Gc3Oz2KUREYnC6qD/wx/+gBdeeKHf+pdeegnZ2dm2qGlY/v73v2PRokVYsGABoqOjsXXrVnh6emL79u1il0ZEJAqrg/6dd97B7bff3m99QkIC9u7da5OihqqrqwulpaVISkoyrXNxcUFSUhJKSkquuE9nZycMBoPZQkQkJ1YH/U8//XTFu035+PigtbXVJkUNVWtrK3p6evrd3SooKAg6ne6K++Tl5UGtVpuW0NBQR5RKROQwVgd9ZGQkDhw40G/9hx9+iHHjxtmkKEfKzc2FXq83LZywjYjkxupx9Dk5OcjKykJLSwtmzJgBACgsLMTf/vY35Ofn27o+q/j7+8PV1RVNTU1m65uamqDVaq+4j0qlgkqlckR5RESiGNJcN52dnXj22Wexdu1aAEB4eDi2bNmChx9+2OYFWkOpVCIuLg6FhYVISUkBcGk4aGFhIbKyskStjYhILEO6Z2xGRgYyMjLQ0tICDw8PeHl52bquIcvJyUFaWhpuu+02TJ48Gfn5+Th//rzZbJtERCPJsG4OHhAQYKs6bOb+++9HS0sLnn76aeh0OsTGxuLAgQP9PqAlIhopLPowduLEiTh79qzFB73jjjtQX18/5KKGKysrC2fOnEFnZyeOHj2KKVOmiFaLJHEul4Hx2pAEWdSiLysrQ3l5Ofz8/Cw6aFlZGTo7O4dVGNmPIHCWRXuR8zw3JF0Wd93MnDkTls5/xpuREBE5D4uCvrq62uoDjx071up9iIjI9iwK+muvvdbedZCzWSNwuuK+2D9PEiW72SvJMuxLtj1eU3JWDHoiIplj0NPA2FXxP7wWJGEMeiIimbM66NPS0nDw4EF71EIOZlGfMluyFl0D9s+TM7M66PV6PZKSkhAVFYV169aJ+g1YIiIanNVBv2/fPtTX1yMjIwO7d+9GeHg4Zs+ejb1796K7u9seNZIdsVU/CLbmSQaG1EcfEBCAnJwclJeX4+jRo4iMjERqaipCQkKwbNky/PDDD7auk4iIhmhYH8Y2NjaioKAABQUFcHV1xa9//WucPHkS0dHR2Lhxo61qJDtjq34AbM2TTFgd9N3d3XjnnXcwZ84cXHvttdizZw+ys7PR0NCA1157DZ988gnefvttPPPMM/aol4iIrGT1fPTBwcEwGo148MEHcezYMcTGxvbbZvr06dBoNDYojxzFohktR9K0CGzNk4xYHfQbN27EvHnz4O7uPuA2Go1mSBOhkQSMhLAfid1UJGtWd92kpqZeNeRJuixuoco5CC18bWzNk5Twm7E0NHIMezm+JiIw6KkPq1qqcgpGK14LW/MkNQx66mfEhT1DnmSOQU9XNGLCniFPIwCDnmxDimEvxZqJhoBBTwOyugUrpeC0sla25knKrB5HTyOLRV+kulxvgDrrWPsh/DJiyJPUMehpUFaHPeB8gT/EvzYY8iQHDHqyyJDCHhA/8IfRncSQJ7lg0JPFhhz2gOMDf5ifFzDkSU4Y9GSV3gAcduADtg99G3wYzIAnOWLQ05AMq3Xfq28wWxv8Nh7lw5AnuZJM0D/77LN4//33UVZWBqVSiba2tn7b1NbWIiMjA5999hm8vLyQlpaGvLw8jBolmZcpKTYJ+8uJODyTIU9yJpkE7Orqwrx58xAfH49XX3213/M9PT24++67odVqceTIETQ2NuLhhx+Gm5sb1q1bJ0LFI8Owu3JExoCnkUAhCNL6Ud+5cyeys7P7teg//PBDzJkzBw0NDQgKCgIAbN26FU8++SRaWlqgVCotOr7BYIBarYZer4ePj4+ty5c9qQS+tH7qnQffH9Ikm2/GlpSUICYmxhTyAJCcnAyDwYBvvvlmwP06OzthMBjMFho6QXDuEHX2+ojsQTZBr9PpzEIegOmxTqcbcL+8vDyo1WrTEhoaatc6RwpnC1Rnq4fIkUQN+hUrVkChUFx1OXXqlF1ryM3NhV6vNy11dXV2Pd9II3bAin1+Imcg6oexy5cvR3p6+lW3GTdunEXH0mq1OHbsmNm6pqYm03MDUalUUKlUFp2Dhq5v2NqrL5+hTtSfqEEfEBCAgIAAmxwrPj4ezz77LJqbmxEYGAgAKCgogI+PD6Kjo21yDrIdWwU/g51ocJIZXllbW4uff/4ZtbW16OnpQVlZGQAgMjISXl5emDVrFqKjo5Gamor169dDp9Nh1apVyMzMZItdAhjYRPYjmeGV6enpeO211/qt/+yzz5CYmAgAOHPmDDIyMlBUVITRo0cjLS0Nzz33nFVfmOLwMaKB8f0hTZIJekfhDzLRwPj+kCbZDK8kIqIrY9ATEckcg56ISOYY9EREMsegJyKSOQY9EZHMMeiJiGSOQU9EJHMMeiIimWPQExHJHIOeiEjmGPRERDLHoCcikjkGPRGRzDHoiYhkjkFPRCRzDHoiIplj0BMRyRyDnohI5hj0REQyx6AnIpI5Bj0Rkcwx6ImIZI5BT0Qkcwx6IiKZY9ATEckcg56ISOYY9EREMsegJyKSOUkEfU1NDRYuXIiIiAh4eHjguuuuw+rVq9HV1WW23ddff40777wT7u7uCA0Nxfr160WqmIjIeYwSuwBLnDp1CkajEdu2bUNkZCQqKiqwaNEinD9/Hhs2bAAAGAwGzJo1C0lJSdi6dStOnjyJRx55BBqNBosXLxb5FRARiUchCIIgdhFD8fzzz2PLli34z3/+AwDYsmULVq5cCZ1OB6VSCQBYsWIF9u3bh1OnTll8XIPBALVaDb1eDx8fH7vUTiRVfH9IkyS6bq5Er9fDz8/P9LikpARTp041hTwAJCcno7KyEmfPnh3wOJ2dnTAYDGYLEZGcSDLoq6qq8OKLL2LJkiWmdTqdDkFBQWbb9T7W6XQDHisvLw9qtdq0hIaG2qdoIiKRiBr0K1asgEKhuOrSt9ulvr4ed911F+bNm4dFixYNu4bc3Fzo9XrTUldXN+xjEhE5E1E/jF2+fDnS09Ovus24ceNM/25oaMD06dORkJCAV155xWw7rVaLpqYms3W9j7Va7YDHV6lUUKlUVlZORCQdogZ9QEAAAgICLNq2vr4e06dPR1xcHHbs2AEXF/M/RuLj47Fy5Up0d3fDzc0NAFBQUIDx48fD19fX5rUTEUmFJPro6+vrkZiYiLCwMGzYsAEtLS3Q6XRmfe8PPfQQlEolFi5ciG+++Qa7d+/Gpk2bkJOTI2LlRETik8Q4+oKCAlRVVaGqqgpjx441e653dKharcbHH3+MzMxMxMXFwd/fH08//TTH0BPRiCfZcfT2wnHCRAPj+0OaJNF1Q0REQ8egJyKSOQY9EZHMMeiJiGSOQU9EJHMMeiIimWPQExHJHIOeiEjmGPRERDLHoCcikjkGPRGRzDHoiYhkThKzVzpS7xxvvHcsUX+97wvOhSgtDPo+2tvbAYD3jiW6ivb2dqjVarHLIAtxmuI+jEYjGhoa4O3tDYVCMezjGQwGhIaGoq6ujtO6DgGv3/DY+voJgoD29naEhIT0u8sbOS+26PtwcXHpd3MTW/Dx8WFQDQOv3/DY8vqxJS89/JVMRCRzDHoiIplj0NuZSqXC6tWroVKpxC5Fknj9hofXjwB+GEtEJHts0RMRyRyDnohI5hj0REQyx6AnIpI5Br0d1NTUYOHChYiIiICHhweuu+46rF69Gl1dXWbbff3117jzzjvh7u6O0NBQrF+/XqSKndPmzZsRHh4Od3d3TJkyBceOHRO7JKeUl5eHSZMmwdvbG4GBgUhJSUFlZaXZNh0dHcjMzMSYMWPg5eWFuXPnoqmpSaSKydEY9HZw6tQpGI1GbNu2Dd988w02btyIrVu34qmnnjJtYzAYMGvWLFx77bUoLS3F888/jzVr1uCVV14RsXLnsXv3buTk5GD16tX46quvcMsttyA5ORnNzc1il+Z0iouLkZmZiS+++AIFBQXo7u7GrFmzcP78edM2y5Ytw7///W/s2bMHxcXFaGhowH333Sdi1eRQAjnE+vXrhYiICNPjl19+WfD19RU6OztN65588klh/PjxYpTndCZPnixkZmaaHvf09AghISFCXl6eiFVJQ3NzswBAKC4uFgRBENra2gQ3Nzdhz549pm2+++47AYBQUlIiVpnkQGzRO4her4efn5/pcUlJCaZOnQqlUmlal5ycjMrKSpw9e1aMEp1GV1cXSktLkZSUZFrn4uKCpKQklJSUiFiZNOj1egAw/byVlpaiu7vb7HpOmDABYWFhvJ4jBIPeAaqqqvDiiy9iyZIlpnU6nQ5BQUFm2/U+1ul0Dq3P2bS2tqKnp+eK12ekX5vBGI1GZGdn4/bbb8dNN90E4NLPk1KphEajMduW13PkYNBbYcWKFVAoFFddTp06ZbZPfX097rrrLsybNw+LFi0SqXIaKTIzM1FRUYFdu3aJXQo5EU5TbIXly5cjPT39qtuMGzfO9O+GhgZMnz4dCQkJ/T5k1Wq1/UY99D7WarW2KVii/P394erqesXrM9KvzdVkZWVh//79OHjwoNlU21qtFl1dXWhrazNr1fN6jhwMeisEBAQgICDAom3r6+sxffp0xMXFYceOHf1u0hAfH4+VK1eiu7sbbm5uAICCggKMHz8evr6+Nq9dSpRKJeLi4lBYWIiUlBQAl7okCgsLkZWVJW5xTkgQBCxduhTvvvsuioqKEBERYfZ8XFwc3NzcUFhYiLlz5wIAKisrUVtbi/j4eDFKJkcT+9NgOfrxxx+FyMhIYebMmcKPP/4oNDY2mpZebW1tQlBQkJCamipUVFQIu3btEjw9PYVt27aJWLnz2LVrl6BSqYSdO3cK3377rbB48WJBo9EIOp1O7NKcTkZGhqBWq4WioiKzn7ULFy6YtnnssceEsLAw4dNPPxWOHz8uxMfHC/Hx8SJWTY7EoLeDHTt2CACuuFyuvLxcuOOOOwSVSiVcc801wnPPPSdSxc7pxRdfFMLCwgSlUilMnjxZ+OKLL8QuySkN9LO2Y8cO0za//PKL8Pjjjwu+vr6Cp6en8Nvf/tas4UHyxmmKiYhkjqNuiIhkjkFPRCRzDHoiIplj0BMRyRyDnohI5hj0REQyx6AnIpI5Bj2JpqamxjQZXGxsrF3PtXPnTtO5srOz7XouImfDoCfRffLJJygsLLTrOe6//340NjZybhcakTipGYluzJgxGDNmjF3P4eHhAQ8PD7MbvRCNFGzRk020tLRAq9Vi3bp1pnVHjhyBUqkcUmt9+/btuPHGG6FSqRAcHGw2a6VCocC2bdswZ84ceHp64oYbbkBJSQmqqqqQmJiI0aNHIyEhAadPn7bJayOSOgY92URAQAC2b9+ONWvW4Pjx42hvb0dqaiqysrIwc+ZMq461ZcsWZGZmYvHixTh58iTee+89REZGmm2zdu1aPPzwwygrK8OECRPw0EMPYcmSJcjNzcXx48chCAKnNCbqJfKkaiQzjz/+uHD99dcLDz30kBATEyN0dHQMuG11dbUAQDhx4oTZ+pCQEGHlypUD7gdAWLVqlelxSUmJAEB49dVXTeveeustwd3dvd++06ZNE/74xz9a/oKIZIAterKpDRs24OLFi9izZw/eeOMNqFQqq/Zvbm5GQ0PDoH8F3HzzzaZ/995bNiYmxmxdR0cHDAaDVecnkiMGPdnU6dOn0dDQAKPRiJqaGqv39/DwsGi73rtyAZf67AdaZzQara6BSG4Y9GQzXV1dmD9/Pu6//36sXbsWjz76KJqbm606hre3N8LDw+0+3JJoJOHwSrKZlStXQq/X44UXXoCXlxc++OADPPLII9i/f79Vx1mzZg0ee+wxBAYGYvbs2Whvb8fhw4exdOlSO1VOJG9s0ZNNFBUVIT8/H6+//jp8fHzg4uKC119/HYcOHcKWLVusOlZaWhry8/Px8ssv48Ybb8ScOXPwww8/2KlyIvnjrQRJNDU1NYiIiMCJEyfsPgVCr8TERMTGxiI/P98h5yNyBmzRk+gSEhKQkJBg13O88cYb8PLywqFDh+x6HiJnxBY9iebixYumkTkqlQqhoaF2O1d7ezuampoAABqNBv7+/nY7F5GzYdATEckcu26IiGSOQU9EJHMMeiIimWPQExHJHIOeiEjmGPRERDLHoCcikjkGPRGRzDHoiYhk7v8BlgdCuPhTr2cAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 258.065x259.74 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "model.plot(color_by='material', colors=material_colors, legend=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dag_cells = dag_univ.get_all_cells()\n",
+    "fuel_cell = dag_cells[1]\n",
+    "fuel_cell.fill = water"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: xlabel='x [cm]', ylabel='y [cm]'>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAEHCAYAAACgHI2PAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAImxJREFUeJzt3X1UVHX+B/D3gMwAAgPIwEBCYJBGUSSpC5WiciQ329hct4ejgZmagbuInU3STX+5SWvuipWpnU1tPZWmndzWyiIKNCVNEpJKCheEgOGhZAY1HoT7+6Nl1gGRGebhzr3zfp1zz3Hu3IfPXGfe8+V773yvQhAEAUREJFtuYhdARET2xaAnIpI5Bj0Rkcwx6ImIZI5BT0Qkcwx6IiKZY9ATEckcg56ISOZGiF2As+nt7UVDQwN8fX2hUCjELofIqQiCgPb2doSFhcHNbeh2Ym9vL7q6uhxQmWvx8PCAu7u72csz6PtpaGhAeHi42GUQObW6ujqMHj36qst0dXWhuroavb29DqrKtfj7+0Or1ZrVIGXQ9+Pr6wvglzeyn5+fyNUQOReDwYDw8HDj52QwgiCgsbER7u7uCA8PN6v1T+YRBAEXL15Ec3MzACA0NHTIdRj0/fR9O/r5+THoiQYxVCvy0qVLuHjxIsLCwuDt7e2gqlyHl5cXAKC5uRnBwcFDduPwa5aIbK6npwcAoFQqRa5Evvq+QLu7u4dclkFPRHbDCxrsx5Jjy6AnIpI59tETkcPU6mvRerHVYfsL8g5ChDrC7OUFQcDixYuxb98+nDt3DidPnkR8fLxVNaxZswb79+9HWVmZVduxBoOeiByiVl+LsS+NRcelDoft03OEJyqzKs0O+4MHD2Lnzp0oKirCmDFjEBQUZOcKHYNBT0QO0Xqx1aEhDwAdlzrQerHV7KA/c+YMQkNDkZSUZOfKHIt99EREADIyMrB06VLU1tZCoVAgMjISkZGRyM/PN1kuPj4ea9asMT5ua2vDo48+Co1GAz8/P0ybNg3l5eWOLX4IDHoiIgCbNm3CM888g9GjR6OxsRFffPGFWevNmTMHzc3N+OCDD1BaWorx48dj+vTp+Omnn+xcsfkY9EREANRqNXx9feHu7g6tVguNRjPkOp999hmOHz+OvXv34rbbbkNMTAw2bNgAf39/7Nu3zwFVm4d99EREw1ReXo7z589j1KhRJvN//vlnnDlzRqSqBmLQExENws3NDYIgmMy7/Jeo58+fR2hoKIqKigas6+/vb+fqzMegJyIahEajQWNjo/GxwWBAdXW18fH48eOh0+kwYsQIREZGilChedhHT0Q0iGnTpmHXrl04fPgwTp06hfT0dJMBxFJSUpCYmIi0tDR89NFHqKmpwdGjR7Fy5UqcOHFCxMpNSSbo8/LyMGHCBPj6+iI4OBhpaWmorKw0WaajowOZmZkYNWoUfHx8MHv2bDQ1NYlUMRFdLsg7CJ4jPB26T88RngjyHv6PnnJzczFlyhTMmjULd999N9LS0nDdddcZn1coFHj//fcxefJkzJ8/H9dffz0eeOABnD17FiEhIbZ4CTahEPp3QDmpu+66Cw888AAmTJiAS5cu4amnnkJFRQW++eYbjBw5EgCwZMkSvPfee9i5cyfUajWysrLg5uaGI0eOmL0fg8EAtVoNvV7PYYqJ+jH389HR0YHq6mpERUXB0/N/4e7sQyBIyWDH+EokE/T9tbS0IDg4GMXFxZg8eTL0ej00Gg3eeOMN/O53vwMAnD59GjfccANKSkrwq1/9yqztMuiJBmdt0JPtWHKMJdN1059erwcABAYGAgBKS0vR3d2NlJQU4zLjxo1DREQESkpKBt1OZ2cnDAaDyUREJCeSDPre3l5kZ2fj9ttvx0033QQA0Ol0UCqVAy5pCgkJgU6nG3RbeXl5UKvVxon3iyUiuZFk0GdmZqKiogK7d++2elu5ubnQ6/XGqa6uzgYVEhE5D8ldR5+VlYUDBw7g0KFDJneh12q16OrqQltbm0mrvqmpCVqtdtDtqVQqqFQqe5ZMRCQqybToBUFAVlYW3nnnHXzyySeIiooyeT4hIQEeHh4oLCw0zqusrERtbS0SExMdXS4RkdOQTIs+MzMTb7zxBv71r3/B19fX2O+uVqvh5eUFtVqNBQsWICcnB4GBgfDz88PSpUuRmJho9hU3RERyJJmg37JlCwAgOTnZZP6OHTuQkZEBANi4cSPc3Nwwe/ZsdHZ2IjU1FS+//LKDKyUici6SCXpzLvf39PTE5s2bsXnzZgdUREQkDZIJeiKSvtpaoNVxP4xFUBAQIc8fxlqEQU9EDlFbC4wdC3Q48Laxnp5AZaV4YZ+cnIz4+PgBtyN0NMlcdUNE0tba6tiQB37ZnyP/grCXrq4uq9Zn0BMR/deBAwfg7++Pnp4eAEBZWRkUCgVWrFhhXObRRx/F3Llz8eOPP+LBBx/ENddcA29vb8TFxeHNN980LpeRkYHi4mJs2rQJCoUCCoUCNTU1AICKigrMnDkTPj4+CAkJwbx589B62TdScnIysrKykJ2djaCgIKSmplr1uhj0RET/deedd6K9vR0nT54EABQXFyMoKMjkDlLFxcVITk5GR0cHEhIS8N5776GiogKLFi3CvHnzcPz4cQC/3Gw8MTERCxcuRGNjIxobGxEeHo62tjZMmzYNt956K06cOIGDBw+iqakJv//9701qee2116BUKnHkyBFs3brVqtfFPnoiov9Sq9WIj49HUVERbrvtNhQVFWHZsmX4v//7P5w/fx56vR5VVVWYMmUKrrnmGjzxxBPGdZcuXYoPP/wQb731FiZOnAi1Wg2lUglvb2+TX+e/9NJLuPXWW7Fu3TrjvO3btyM8PBzfffcdrr/+egBATEwM1q9fb5PXxRY9EdFlpkyZgqKiIgiCgMOHD+O+++7DDTfcgM8++wzFxcUICwtDTEwMenp6sHbtWsTFxSEwMBA+Pj748MMPUVtbe9Xtl5eX49NPP4WPj49xGjduHACY3FA8ISHBZq+JLXoiosskJydj+/btKC8vh4eHB8aNG4fk5GQUFRXh3LlzmDJlCgDg+eefx6ZNm5Cfn4+4uDiMHDkS2dnZQ544PX/+PO655x789a9/HfBcaGio8d99N1SyBQY9EdFl+vrpN27caAz15ORkPPfcczh37hyWL18OADhy5AjuvfdezJ07F8Avw6d/9913iI2NNW5LqVQaT+z2GT9+PN5++21ERkZixAjHRDC7boiILhMQEICbb74Zr7/+unHIlcmTJ+PLL7/Ed999Zwz/mJgYFBQU4OjRo/j222+xePHiAfeojoyMxLFjx1BTU4PW1lb09vYiMzMTP/30Ex588EF88cUXOHPmDD788EPMnz9/wJeCrTDoicghgoJ++QGTI3l6/rJfS02ZMgU9PT3GoA8MDERsbCy0Wi3Gjh0LAFi1ahXGjx+P1NRUJCcnQ6vVIi0tzWQ7TzzxBNzd3REbGwuNRoPa2lqEhYXhyJEj6OnpwYwZMxAXF4fs7Gz4+/vDzc0+kSzZe8baC+8ZSzQ4q28OziEQbMaSe8ayj56IHCYiQr7B68zYdUNEJHMMeiIimWPQExHJHIOeiOyG13rYjyXHlkFPRDbn7u4OwPrhdWlwFy9eBAB4eHgMuSyvuiEimxsxYgS8vb3R0tICDw8Pu10f7ooEQcDFixfR3NwMf39/45fq1TDoicjmFAoFQkNDUV1djbNnz4pdjiz5+/ubjIp5NQx6IrILpVKJmJgYdt/YgYeHh1kt+T4MeiKyGzc3tyF/tUn2x44zIiKZY9ATEckcg56ISOYY9EREMsegJyKSOQY9EZHMMeiJiGROUkF/6NAh3HPPPQgLC4NCocD+/ftNnhcEAU8//TRCQ0Ph5eWFlJQUfP/99+IUSxZRKIY3EdHQJBX0Fy5cwC233ILNmzdf8fn169fjhRdewNatW3Hs2DGMHDkSqamp6OjocHClNBRbBTaDn2hokvpl7MyZMzFz5swrPicIAvLz87Fq1Srce++9AIB//vOfCAkJwf79+/HAAw84slTqx1Eh3H8/HCWXSGIt+quprq6GTqdDSkqKcZ5arcakSZNQUlIy6HqdnZ0wGAwmE9mO2C1tsfdP5AxkE/Q6nQ4AEBISYjI/JCTE+NyV5OXlQa1WG6fw8HC71ukqnC1gna0eIkeSTdAPV25uLvR6vXGqq6sTuyRJc/ZAdfb6iOxBUn30V9M3LnNTUxNCQ0ON85uamhAfHz/oeiqVCiqVyt7lyZ7UwrOvXvbhkyuQTYs+KioKWq0WhYWFxnkGgwHHjh1DYmKiiJXJm9RbyFKvn8gckmrRnz9/HlVVVcbH1dXVKCsrQ2BgICIiIpCdnY2//OUviImJQVRUFP785z8jLCwMaWlp4hUtYzYPyDUWbnCN7ZrjCgVb9yRfkgr6EydOYOrUqcbHOTk5AID09HTs3LkTf/rTn3DhwgUsWrQIbW1tuOOOO3Dw4EHe+MAObBLylgb7UOtbGfwMe5IrhSDwrX05g8EAtVoNvV4PPz8/sctxOlYHvLXhbvZ+rHtb81NxZfx8SJOkWvQkLqtC3lEB339/wwx8tu5JThj0ZJZhh7yjA36w/Q8j8Bn2JBcMehrSsEJe7IDvb5iBz7AnOWDQ01VZHPLOFvD9DSPwGfYkdbK5jp5sT3YhfzkLa+W19iRlbNGTbdgq5M1tadtif2sUNr0Wn8hZMejpiixqwVoTusMN2v7rDbcGC8KeXTgkVQx6GsDuIW+PVvTl27T4F7YMe5I39tGTCbuG/BrBMV0lw9mPBa+F/fUkNQx6Gh4Rx6Wx2z6ldDKZyAIMejIyu6VqSSA6qhVvq/2b+drYqicpYdCTZSwNeWdhh7AnkgqzTsb2jRJpiVWrViEwMNDi9UgcZrVQpRryfdYI5r8GM07Q8sQsSYVZo1e6ubkhMTERSqXSrI1+9tlnqKysxJgxY6wu0NFcdXQ+mwa9M4b85Wz4Olwt6F318yF1Zl9e+c477yA4ONisZX19fYddEDmeS4U8YH7Lnq16kgmz+uh37NgBtVpt9ka3bduGkJCQYRdFEiWFkO8jpVqJrMQbj/Tjan+a2qw1L9XgtNFrc5VPkat9PuTCql/Gnj9/Hr29vSbz+J9PRORcLL68srq6GnfffTdGjhwJtVqNgIAABAQEwN/fHwEBAfaokezE5VvzgHm1m3EMeF09OTOLW/Rz586FIAjYvn07QkJCoOA73LVJOeT7WHLZJZEEWRz05eXlKC0txdixY+1RDzkTht//cEhjkjCLu24mTJiAuro6e9RCUiOn4JPTayHqx+IW/T/+8Q889thjqK+vx0033QQPDw+T52+++WabFUf2wx432+M19eSsLA76lpYWnDlzBvPnzzfOUygUEAQBCoUCPT09Ni2QRMJum4HYfUMSZXHQP/LII7j11lvx5ptv8mSsK5Nj4PGkLMmUxUF/9uxZvPvuu4iOjrZHPUREZGMWn4ydNm0aysvL7VELOQj/CLMfHltyRha36O+55x4sW7YMp06dQlxc3ICTsb/5zW9sVhyJhN0Xg2M/PUmQxWPduLkN/keAHE7GusJYHkO2OocKerkHnZWvX85X3rjC50OOLO666e3tHXRylpDfvHkzIiMj4enpiUmTJuH48eNil0REJBrZ3Upwz549yMnJwerVq/Hll1/illtuQWpqKpqbm8UujYhIFBYH/R/+8Ae88MILA+a/9NJLyM7OtkVNVvn73/+OhQsXYv78+YiNjcXWrVvh7e2N7du3i10aEZEoLA76t99+G7fffvuA+UlJSdi3b59Nihqurq4ulJaWIiUlxTjPzc0NKSkpKCkpueI6nZ2dMBgMJhMRkZxYHPQ//vjjFe825efnh9bWVpsUNVytra3o6ekZcHerkJAQ6HS6K66Tl5cHtVptnMLDwx1RKhGRw1gc9NHR0Th48OCA+R988IEkbwaem5sLvV5vnDhgGxHJjcXX0efk5CArKwstLS2YNm0aAKCwsBB/+9vfkJ+fb+v6LBIUFAR3d3c0NTWZzG9qaoJWq73iOiqVCiqVyhHlERGJYlhj3XR2duLZZ5/F2rVrAQCRkZHYsmULHn74YZsXaAmlUomEhAQUFhYiLS0NwC+XgxYWFiIrK0vU2oiIxDKse8YuWbIES5YsQUtLC7y8vODj42PruoYtJycH6enpuO222zBx4kTk5+fjwoULJqNtEhG5EqtuDq7RaGxVh83cf//9aGlpwdNPPw2dTof4+HgcPHhwwAlasoKchwHg8A8kQ2adjB0/fjzOnTtn9kbvuOMO1NfXD7soa2VlZeHs2bPo7OzEsWPHMGnSJNFqkSS5hrgt8NiQBJnVoi8rK0N5eTkCAwPN2mhZWRk6OzutKozsRxA4yqK9yHmcG5Ius7tupk+fDnPHP+PNSIiInIdZQV9dXW3xhkePHm3xOiQhcuynZ/88yZRZQX/ttdfauw5yNryt3kBy+2IjlyG70SvJPOxLtj0eU3JWDHoaPjm1+OX0Woj6YdDT4NhV8T88FiRhDHqyjhxawnJ4DURXYXHQp6en49ChQ/aohRzMrD5lc1qyUg5Kc2o34xiwf56cmcVBr9frkZKSgpiYGKxbt07UX8ASEdHQLA76/fv3o76+HkuWLMGePXsQGRmJmTNnYt++feju7rZHjWRHLt2qZ2ueXMSw+ug1Gg1ycnJQXl6OY8eOITo6GvPmzUNYWBiWLVuG77//3tZ1khRIKeylVCuRlaw6GdvY2IiCggIUFBTA3d0dv/71r3Hq1CnExsZi48aNtqqR7MxmrXpAGgFqbo1szZNMWBz03d3dePvttzFr1ixce+212Lt3L7Kzs9HQ0IDXXnsNH3/8Md566y0888wz9qiXpMCZw96ZayOyE4vHow8NDUVvby8efPBBHD9+HPHx8QOWmTp1Kvz9/W1QHjmKWSNaWjIsgjOOhWNJyLM1TzKiEMwdkvK/du3ahTlz5sDT09NeNYnKYDBArVZDr9fDz89P7HIcyuxBR20cmA5hh5pdMehd+fMhZRYHvdy5+hvZLmEPiBf4dqrTVT81rv75kCr+MpaGx9LgFqNvXCpfRkR2xqAnExa1VIcT9o4I/OHsx4LX4qqteZIuq24OTvJk0a0GhzNu/eXL26oVbc0XCEOeZI5BT1dk97A3rttvPUdfr8+QJxfAoCfbsNUdqRzZl88+eXIR7KOnQVncgpVScFpYK1vzJGVs0dNVWdSFA/wvQJ31F6jD+DJiyJPUMehpSBaHPeB8gT/MvzYY8iQHDHoyy7DCHhA/8K3oTmLIk1ww6Mlsww57wPGBb+X5AoY8yQmDnizSF4BWBz5g+9C3wclgBjzJEYOehsWq1n2f/sEs8pAFDHmSK8kE/bPPPov33nsPZWVlUCqVaGtrG7BMbW0tlixZgk8//RQ+Pj5IT09HXl4eRoyQzMuUFJuE/eVEvDyTIU9yJpkE7Orqwpw5c5CYmIhXX311wPM9PT24++67odVqcfToUTQ2NuLhhx+Gh4cH1q1bJ0LFrsHqrhyRMeDJFUhumOKdO3ciOzt7QIv+gw8+wKxZs9DQ0ICQkBAAwNatW/Hkk0+ipaUFSqXSrO1zGFbrSCXwpfWudx78fEiTbH4ZW1JSgri4OGPIA0BqaioMBgO+/vrrQdfr7OyEwWAwmWj4BMG5Q9TZ6yOyB9kEvU6nMwl5AMbHOp1u0PXy8vKgVquNU3h4uF3rdBXOFqjOVg+RI4ka9CtWrIBCobjqdPr0abvWkJubC71eb5zq6ursuj9XI3bAir1/Imcg6snY5cuXIyMj46rLjBkzxqxtabVaHD9+3GReU1OT8bnBqFQqqFQqs/ZBw9c/bO3Vl89QJxpI1KDXaDTQaDQ22VZiYiKeffZZNDc3Izg4GABQUFAAPz8/xMbG2mQfZDu2Cn4GO9HQJHN5ZW1tLX766SfU1taip6cHZWVlAIDo6Gj4+PhgxowZiI2Nxbx587B+/XrodDqsWrUKmZmZbLFLAAObyH4kc3llRkYGXnvttQHzP/30UyQnJwMAzp49iyVLlqCoqAgjR45Eeno6nnvuOYt+MMXLx4gGx8+HNEkm6B2Fb2SiwfHzIU2yubySiIiujEFPRCRzDHoiIplj0BMRyRyDnohI5hj0REQyx6AnIpI5Bj0Rkcwx6ImIZI5BT0Qkcwx6IiKZY9ATEckcg56ISOYY9EREMsegJyKSOQY9EZHMMeiJiGSOQU9EJHMMeiIimWPQExHJHIOeiEjmGPRERDLHoCcikjkGPRGRzDHoiYhkjkFPRCRzDHoiIplj0BMRyRyDnohI5iQR9DU1NViwYAGioqLg5eWF6667DqtXr0ZXV5fJcl999RXuvPNOeHp6Ijw8HOvXrxepYiIi5zFC7ALMcfr0afT29mLbtm2Ijo5GRUUFFi5ciAsXLmDDhg0AAIPBgBkzZiAlJQVbt27FqVOn8Mgjj8Df3x+LFi0S+RUQEYlHIQiCIHYRw/H8889jy5Yt+M9//gMA2LJlC1auXAmdTgelUgkAWLFiBfbv34/Tp0+bvV2DwQC1Wg29Xg8/Pz+71E4kVfx8SJMkum6uRK/XIzAw0Pi4pKQEkydPNoY8AKSmpqKyshLnzp0bdDudnZ0wGAwmExGRnEgy6KuqqvDiiy9i8eLFxnk6nQ4hISEmy/U91ul0g24rLy8ParXaOIWHh9unaCIikYga9CtWrIBCobjq1L/bpb6+HnfddRfmzJmDhQsXWl1Dbm4u9Hq9caqrq7N6m0REzkTUk7HLly9HRkbGVZcZM2aM8d8NDQ2YOnUqkpKS8Morr5gsp9Vq0dTUZDKv77FWqx10+yqVCiqVysLKiYikQ9Sg12g00Gg0Zi1bX1+PqVOnIiEhATt27ICbm+kfI4mJiVi5ciW6u7vh4eEBACgoKMDYsWMREBBg89qJiKRCEn309fX1SE5ORkREBDZs2ICWlhbodDqTvveHHnoISqUSCxYswNdff409e/Zg06ZNyMnJEbFyIiLxSeI6+oKCAlRVVaGqqgqjR482ea7v6lC1Wo2PPvoImZmZSEhIQFBQEJ5++mleQ09ELk+y19HbC68TJhocPx/SJImuGyIiGj4GPRGRzDHoiYhkjkFPRCRzDHoiIplj0BMRyRyDnohI5hj0REQyx6AnIpI5Bj0Rkcwx6ImIZI5BT0Qkc5IYvdKR+sZ4471jiQbq+1xwLERpYdD3097eDgC8dyzRVbS3t0OtVotdBpmJwxT309vbi4aGBvj6+kKhUFi9PYPBgPDwcNTV1XFY12Hg8bOOrY+fIAhob29HWFjYgLu8kfNii74fNze3ATc3sQU/Pz8GlRV4/Kxjy+PHlrz08CuZiEjmGPRERDLHoLczlUqF1atXQ6VSiV2KJPH4WYfHjwCejCUikj226ImIZI5BT0Qkcwx6IiKZY9ATEckcg94OampqsGDBAkRFRcHLywvXXXcdVq9eja6uLpPlvvrqK9x5553w9PREeHg41q9fL1LFzmnz5s2IjIyEp6cnJk2ahOPHj4tdklPKy8vDhAkT4Ovri+DgYKSlpaGystJkmY6ODmRmZmLUqFHw8fHB7Nmz0dTUJFLF5GgMejs4ffo0ent7sW3bNnz99dfYuHEjtm7diqeeesq4jMFgwIwZM3DttdeitLQUzz//PNasWYNXXnlFxMqdx549e5CTk4PVq1fjyy+/xC233ILU1FQ0NzeLXZrTKS4uRmZmJj7//HMUFBSgu7sbM2bMwIULF4zLLFu2DP/+97+xd+9eFBcXo6GhAffdd5+IVZNDCeQQ69evF6KiooyPX375ZSEgIEDo7Ow0znvyySeFsWPHilGe05k4caKQmZlpfNzT0yOEhYUJeXl5IlYlDc3NzQIAobi4WBAEQWhraxM8PDyEvXv3Gpf59ttvBQBCSUmJWGWSA7FF7yB6vR6BgYHGxyUlJZg8eTKUSqVxXmpqKiorK3Hu3DkxSnQaXV1dKC0tRUpKinGem5sbUlJSUFJSImJl0qDX6wHA+H4rLS1Fd3e3yfEcN24cIiIieDxdBIPeAaqqqvDiiy9i8eLFxnk6nQ4hISEmy/U91ul0Dq3P2bS2tqKnp+eKx8fVj81Qent7kZ2djdtvvx033XQTgF/eT0qlEv7+/ibL8ni6Dga9BVasWAGFQnHV6fTp0ybr1NfX46677sKcOXOwcOFCkSonV5GZmYmKigrs3r1b7FLIiXCYYgssX74cGRkZV11mzJgxxn83NDRg6tSpSEpKGnCSVavVDrjqoe+xVqu1TcESFRQUBHd39yseH1c/NleTlZWFAwcO4NChQyZDbWu1WnR1daGtrc2kVc/j6ToY9BbQaDTQaDRmLVtfX4+pU6ciISEBO3bsGHCThsTERKxcuRLd3d3w8PAAABQUFGDs2LEICAiwee1SolQqkZCQgMLCQqSlpQH4pUuisLAQWVlZ4hbnhARBwNKlS/HOO++gqKgIUVFRJs8nJCTAw8MDhYWFmD17NgCgsrIStbW1SExMFKNkcjSxzwbL0Q8//CBER0cL06dPF3744QehsbHROPVpa2sTQkJChHnz5gkVFRXC7t27BW9vb2Hbtm0iVu48du/eLahUKmHnzp3CN998IyxatEjw9/cXdDqd2KU5nSVLlghqtVooKioyea9dvHjRuMxjjz0mRERECJ988olw4sQJITExUUhMTBSxanIkBr0d7NixQwBwxely5eXlwh133CGoVCrhmmuuEZ577jmRKnZOL774ohARESEolUph4sSJwueffy52SU5psPfajh07jMv8/PPPwuOPPy4EBAQI3t7ewm9/+1uThgfJG4cpJiKSOV51Q0Qkcwx6IiKZY9ATEckcg56ISOYY9EREMsegJyKSOQY9EZHMMehJNDU1NcbB4OLj4+26r507dxr3lZ2dbdd9ETkbBj2J7uOPP0ZhYaFd93H//fejsbGRY7uQS+KgZiS6UaNGYdSoUXbdh5eXF7y8vExu9ELkKtiiJ5toaWmBVqvFunXrjPOOHj0KpVI5rNb69u3bceONN0KlUiE0NNRk1EqFQoFt27Zh1qxZ8Pb2xg033ICSkhJUVVUhOTkZI0eORFJSEs6cOWOT10YkdQx6sgmNRoPt27djzZo1OHHiBNrb2zFv3jxkZWVh+vTpFm1ry5YtyMzMxKJFi3Dq1Cm8++67iI6ONllm7dq1ePjhh1FWVoZx48bhoYcewuLFi5Gbm4sTJ05AEAQOaUzUR+RB1UhmHn/8ceH6668XHnroISEuLk7o6OgYdNnq6moBgHDy5EmT+WFhYcLKlSsHXQ+AsGrVKuPjkpISAYDw6quvGue9+eabgqen54B1p0yZIvzxj380/wURyQBb9GRTGzZswKVLl7B37168/vrrUKlUFq3f3NyMhoaGIf8KuPnmm43/7ru3bFxcnMm8jo4OGAwGi/ZPJEcMerKpM2fOoKGhAb29vaipqbF4fS8vL7OW67srF/BLn/1g83p7ey2ugUhuGPRkM11dXZg7dy7uv/9+rF27Fo8++iiam5st2oavry8iIyPtfrklkSvh5ZVkMytXroRer8cLL7wAHx8fvP/++3jkkUdw4MABi7azZs0aPPbYYwgODsbMmTPR3t6OI0eOYOnSpXaqnEje2KInmygqKkJ+fj527doFPz8/uLm5YdeuXTh8+DC2bNli0bbS09ORn5+Pl19+GTfeeCNmzZqF77//3k6VE8kfbyVIoqmpqUFUVBROnjxp9yEQ+iQnJyM+Ph75+fkO2R+RM2CLnkSXlJSEpKQku+7j9ddfh4+PDw4fPmzX/RA5I7boSTSXLl0yXpmjUqkQHh5ut321t7ejqakJAODv74+goCC77YvI2TDoiYhkjl03REQyx6AnIpI5Bj0Rkcwx6ImIZI5BT0Qkcwx6IiKZY9ATEckcg56ISOYY9EREMvf/TiHNRyQNjKwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 258.065x259.74 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model.plot(color_by='material', colors=material_colors, legend=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "3.12.7",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The new ability to synchronize information about DAGMC models added in https://github.com/openmc-dev/openmc/pull/3056 is really useful for examining and modifying DAGMC universes.

To add:

  - [x] Example of material differentiation
  - [ ] Demo depletion run